### PR TITLE
feat: use VSCode Output channel for extension logging

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -471,7 +471,10 @@ function registerCommands(): void {
       }
 
       try {
-        outputChannel?.debug(`[addToPrompt] Sending "${ref}" to port ${openCodeClient.getPort()}`);
+        const port = openCodeClient.getPort();
+        const workspaceDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || 'unknown';
+        outputChannel?.info(`[addToPrompt] Sending to port ${port}, cwd: ${workspaceDir}`);
+        outputChannel?.debug(`[addToPrompt] Content: "${ref}"`);
         const result = await openCodeClient.appendPrompt(ref);
         outputChannel?.debug(`[addToPrompt] Result: ${result}`);
         showTransientNotification(`Sent: ${ref}`);
@@ -500,7 +503,10 @@ function registerCommands(): void {
       }
 
       try {
-        outputChannel?.debug(`[addToPrompt] Sending "${ref}" to port ${openCodeClient.getPort()}`);
+        const port = openCodeClient.getPort();
+        const workspaceDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || 'unknown';
+        outputChannel?.info(`[addToPrompt] Sending to port ${port}, cwd: ${workspaceDir}`);
+        outputChannel?.debug(`[addToPrompt] Content: "${ref}"`);
         const result = await openCodeClient.appendPrompt(ref);
         outputChannel?.debug(`[addToPrompt] Result: ${result}`);
         showTransientNotification(`Sent: ${ref}`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -268,10 +268,14 @@ export function activate(extensionUri: vscode.Uri, context: vscode.ExtensionCont
   extensionContext = context;
 
   // Create log output channel for user-accessible logging (View → Output → OpenCode Connector)
-  outputChannel = vscode.window.createOutputChannel('OpenCode Connector', { log: true });
-  context.subscriptions.push(outputChannel);
-
-  outputChannel.info('OpenCode Connector extension is now active');
+  try {
+    outputChannel = vscode.window.createOutputChannel('OpenCode Connector', { log: true });
+    context.subscriptions.push(outputChannel);
+    outputChannel.info('OpenCode Connector extension is now active');
+  } catch (err) {
+    // Fallback: use console if OutputChannel fails (e.g., early activation)
+    console.error('Failed to create output channel:', err);
+  }
 
   try {
     // Initialize configuration manager (singleton)

--- a/src/instance/instanceManager.ts
+++ b/src/instance/instanceManager.ts
@@ -83,15 +83,32 @@ export interface DiscoveredProcess {
 }
 
 /**
+ * Logger interface for extension logging
+ */
+export interface Logger {
+  info(message: string): void;
+  warn(message: string): void;
+  error(message: string): void;
+}
+
+/**
  * Instance Manager for OpenCode
  * Provides methods to detect running instances and spawn new ones
  */
 export class InstanceManager {
   private static instance: InstanceManager;
   private configManager: ConfigManager;
+  private logger?: Logger;
 
   private constructor(configManager: ConfigManager) {
     this.configManager = configManager;
+  }
+
+  /**
+   * Set logger for output
+   */
+  public setLogger(logger: Logger): void {
+    this.logger = logger;
   }
 
   /**
@@ -262,7 +279,7 @@ export class InstanceManager {
         // Handle process exit (for detached processes, exit immediately usually means error)
         spawnedProcess.on('exit', (code, signal) => {
           if (code !== null && code !== 0) {
-            console.warn(`OpenCode process exited with code ${code} (signal: ${signal})`);
+            this.logger?.warn(`OpenCode process exited with code ${code} (signal: ${signal})`);
           }
         });
       } catch (err) {


### PR DESCRIPTION
## Summary

Replace browser console.log/warn/error with VSCode's built-in LogOutputChannel API for user-accessible logging.

## Changes

- Add dedicated "OpenCode Connector" channel in VSCode Output tab
- Users can now view logs via **View → Output → OpenCode Connector**
- Log cwd and port when sending files to prompt
- Add defensive error handling for OutputChannel creation

## Benefits

1. **User accessible**: Logs visible in VSCode Output panel
2. **Structured logging**: Use trace/debug/info/warn/error levels
3. **Standard practice**: Used by VSCode's own extensions

Closes #2