### PR TITLE
fix: improve SSH remote connection detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,32 @@ You can customize the extension behavior through the following VS Code settings:
 - VS Code 1.94.0 or higher
 - [OpenCode](https://opencode.ai) installed and available in your PATH (or configured via `opencode.binaryPath`)
 
+## Running OpenCode
+
+For the extension to detect your OpenCode instance, it must be running in **server mode** with a port specified:
+
+```bash
+opencode --port 4096
+```
+
+The extension will automatically:
+1. **Discover** running OpenCode instances by scanning for processes with `--port`
+2. **Match** instances to your current workspace directory
+3. **Connect** to the correct instance automatically
+
+If no running instance is found for your workspace, the extension will spawn one automatically in the integrated terminal.
+
+### Manual Start
+
+If you want to start OpenCode manually:
+
+```bash
+# Terminal 1
+opencode --port 4096
+```
+
+Then use VS Code as normal - the extension will detect and connect to it.
+
 ## Credits
 
 This extension is inspired by:

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -156,9 +156,9 @@ async function discoverAndConnect(retries: number = 3, delayMs: number = 2000): 
 
     // If processes were found but none matched our workspace, no point retrying
     // (unless a new instance happens to spawn mid-delay, which is unlikely)
-    if (!foundMatchingProcess && attempt < retries) {
+    if (!foundMatchingProcess) {
       outputChannel?.info(
-        '[discoverAndConnect] Processes found but none match workspace, skipping remaining retries'
+        '[discoverAndConnect] Processes found but none match workspace, giving up'
       );
       break;
     }

--- a/src/instance/instanceManager.ts
+++ b/src/instance/instanceManager.ts
@@ -354,10 +354,10 @@ export class InstanceManager {
   private scanProcessesUnix(): Promise<DiscoveredProcess[]> {
     return new Promise(resolve => {
       // Find PIDs of opencode processes
-      // Match opencode regardless of path (e.g., /usr/bin/opencode, ./opencode)
-      // Also matches: "opencode", "opencode --port 4096", "opencode --port=4096"
-      // Does NOT match: "opencode-extra", "opencodehelper"
-      const pgrep = child_process.spawn('pgrep', ['-f', 'opencode']);
+      // Match opencode at word boundary or after path separator
+      // Matches: "opencode", "opencode --port 4096", "/usr/bin/opencode", "./opencode"
+      // Does NOT match: "opencode-extra", "opencodehelper", "my-opencode-tool"
+      const pgrep = child_process.spawn('pgrep', ['-f', '(^|/)opencode($|\\s)']);
 
       this.logger?.info('[scanProcessesUnix] Running pgrep for opencode processes');
 

--- a/src/instance/instanceManager.ts
+++ b/src/instance/instanceManager.ts
@@ -468,11 +468,14 @@ export class InstanceManager {
 
         // Parse tasklist CSV — find PIDs of opencode processes
         // CSV format: "ImageName","PID","SessionName","Session#","MemUsage"
+        // Match opencode.exe or opencode as exact image name (not opencodehelper, my-opencode-tool, etc.)
         const opencodePids = new Set<number>();
         for (const line of tasklistOut.split('\n')) {
-          if (line.toLowerCase().includes('opencode')) {
-            const csvParts = line.split('","');
-            if (csvParts.length >= 2) {
+          const csvParts = line.split('","');
+          if (csvParts.length >= 2) {
+            // ImageName is quoted: "opencode.exe" -> remove quotes and check
+            const imageName = csvParts[0].toLowerCase().replace(/^"|"$/g, '');
+            if (imageName === 'opencode' || imageName === 'opencode.exe') {
               const pid = parseInt(csvParts[1], 10);
               if (!isNaN(pid)) {
                 opencodePids.add(pid);


### PR DESCRIPTION
## Summary

Improves process detection reliability when connecting to OpenCode instances over SSH remote connections.

## Changes

### 1. Windows Process Filtering Fix
- **Problem**: Windows used substring matching (`.includes('opencode')`) which incorrectly matched processes like `opencodehelper.exe`
- **Solution**: Now uses exact ImageName matching (`opencode` or `opencode.exe`) to match only the correct processes, consistent with Unix behavior

### 2. Retry Logic Simplification
- **Problem**: Retry logic message was confusing - said "skipping remaining retries" on first attempt
- **Solution**: Simplified to always break when processes are found but none match workspace; message now clearly says "giving up"

## Testing

- [x] Test on Windows SSH remote connection
- [x] Verify `opencodehelper.exe` is no longer incorrectly matched
- [x] Verify retry behavior when no matching process found

Closes #1