### PR TITLE
feat(terminal): add auto-focus after prompt send

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,11 @@
               "hint"
             ]
           }
+        },
+        "opencode.autoFocusTerminal": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically focus OpenCode terminal after sending prompts"
         }
       }
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,6 +41,15 @@ export class ConfigManager {
   }
 
   /**
+   * Get auto focus terminal setting.
+   * @returns Whether to automatically focus the terminal when spawning OpenCode (default: true)
+   */
+  public getAutoFocusTerminal(): boolean {
+    const config = vscode.workspace.getConfiguration('opencode');
+    return config.get<boolean>('autoFocusTerminal') ?? true;
+  }
+
+  /**
    * Set OpenCode server port.
    * @param port - Port number to use
    */
@@ -62,11 +71,12 @@ export class ConfigManager {
    * Get default configuration values.
    * @returns Object containing default values
    */
-  public getDefaults(): { port: number; binaryPath: string; codeActionSeverityLevels: string[] } {
+  public getDefaults(): { port: number; binaryPath: string; codeActionSeverityLevels: string[]; autoFocusTerminal: boolean } {
     return {
       port: 4096,
       binaryPath: '',
       codeActionSeverityLevels: ['error', 'warning', 'information', 'hint'],
+      autoFocusTerminal: true,
     };
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -71,7 +71,12 @@ export class ConfigManager {
    * Get default configuration values.
    * @returns Object containing default values
    */
-  public getDefaults(): { port: number; binaryPath: string; codeActionSeverityLevels: string[]; autoFocusTerminal: boolean } {
+  public getDefaults(): {
+    port: number;
+    binaryPath: string;
+    codeActionSeverityLevels: string[];
+    autoFocusTerminal: boolean;
+  } {
     return {
       port: 4096,
       binaryPath: '',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -329,10 +329,11 @@ export function activate(extensionUri: vscode.Uri, context: vscode.ExtensionCont
 
     // Set up logger for InstanceManager to use the OutputChannel
     if (outputChannel) {
+      const channel = outputChannel;
       instanceManager.setLogger({
-        info: (msg: string) => outputChannel.info(msg),
-        warn: (msg: string) => outputChannel.warn(msg),
-        error: (msg: string) => outputChannel.error(msg),
+        info: (msg: string) => channel.info(msg),
+        warn: (msg: string) => channel.warn(msg),
+        error: (msg: string) => channel.error(msg),
       });
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -521,6 +521,19 @@ function registerCommands(): void {
         const result = await openCodeClient.appendPrompt(ref);
         outputChannel?.debug(`[addToPrompt] Result: ${result}`);
         showTransientNotification(`Sent: ${ref}`);
+        // Auto-focus terminal if enabled
+        if (ConfigManager.getInstance().getAutoFocusTerminal()) {
+          outputChannel?.debug(`[addToPrompt] Auto-focus enabled, attempting to focus terminal`);
+          try {
+            const focused = await InstanceManager.getInstance().focusTerminal();
+            outputChannel?.debug(`[addToPrompt] Terminal focus result: ${focused}`);
+          } catch (err) {
+            outputChannel?.warn(`[addToPrompt] Terminal focus error: ${(err as Error).message}`);
+            // Silently ignore focus errors - don't fail the main operation
+          }
+        } else {
+          outputChannel?.debug(`[addToPrompt] Auto-focus disabled in config`);
+        }
       } catch (err) {
         await vscode.window.showErrorMessage(`Failed to send reference: ${(err as Error).message}`);
       }
@@ -553,6 +566,19 @@ function registerCommands(): void {
         const result = await openCodeClient.appendPrompt(ref);
         outputChannel?.debug(`[addToPrompt] Result: ${result}`);
         showTransientNotification(`Sent: ${ref}`);
+        // Auto-focus terminal if enabled
+        if (ConfigManager.getInstance().getAutoFocusTerminal()) {
+          outputChannel?.debug(`[addToPrompt] Auto-focus enabled, attempting to focus terminal`);
+          try {
+            const focused = await InstanceManager.getInstance().focusTerminal();
+            outputChannel?.debug(`[addToPrompt] Terminal focus result: ${focused}`);
+          } catch (err) {
+            outputChannel?.warn(`[addToPrompt] Terminal focus error: ${(err as Error).message}`);
+            // Silently ignore focus errors - don't fail the main operation
+          }
+        } else {
+          outputChannel?.debug(`[addToPrompt] Auto-focus disabled in config`);
+        }
       } catch (err) {
         await vscode.window.showErrorMessage(`Failed to send reference: ${(err as Error).message}`);
       }
@@ -579,6 +605,14 @@ function registerCommands(): void {
         );
         await openCodeClient.appendPrompt(prompt);
         showTransientNotification(`Sent explanation request for diagnostic`);
+        // Auto-focus terminal if enabled
+        if (ConfigManager.getInstance().getAutoFocusTerminal()) {
+          try {
+            await InstanceManager.getInstance().focusTerminal();
+          } catch {
+            // Silently ignore focus errors - don't fail the main operation
+          }
+        }
       } catch (err) {
         await vscode.window.showErrorMessage(
           `Failed to send explanation: ${(err as Error).message}`
@@ -607,6 +641,14 @@ function registerCommands(): void {
         );
         await openCodeClient.appendPrompt(prompt);
         showTransientNotification(`Sent explanation request for diagnostic`);
+        // Auto-focus terminal if enabled
+        if (ConfigManager.getInstance().getAutoFocusTerminal()) {
+          try {
+            await InstanceManager.getInstance().focusTerminal();
+          } catch {
+            // Silently ignore focus errors - don't fail the main operation
+          }
+        }
       } catch (err) {
         await vscode.window.showErrorMessage(
           `Failed to send explanation: ${(err as Error).message}`

--- a/src/instance/instanceManager.ts
+++ b/src/instance/instanceManager.ts
@@ -647,6 +647,49 @@ export class InstanceManager {
   private getWorkspacePath(): string {
     return WorkspaceUtils.getWorkspacePath();
   }
+
+  /**
+   * Focus an existing OpenCode terminal by workspace hash
+   * @param workspaceHash - Optional workspace hash to find specific terminal
+   * @returns Promise<boolean> - true if terminal was found and focused, false otherwise
+   */
+  public async focusTerminal(workspaceHash?: string): Promise<boolean> {
+    // Debug: log all available terminals
+    const allTerminals = vscode.window.terminals.map(t => t.name);
+    this.logger?.info(`[focusTerminal] Available terminals: ${JSON.stringify(allTerminals)}`);
+
+    // Try multiple matching strategies
+    
+    // 1. Match "OpenCode: <hash>" (the standard pattern from spawnInTerminal)
+    let terminal = vscode.window.terminals.find(t =>
+      t.name.startsWith('OpenCode: ')
+    );
+
+    // 2. Match "opencode" case-insensitively (for manually created terminals)
+    if (!terminal) {
+      terminal = vscode.window.terminals.find(t =>
+        t.name.toLowerCase() === 'opencode'
+      );
+    }
+
+    // 3. Match any terminal containing "opencode" (most permissive)
+    if (!terminal) {
+      terminal = vscode.window.terminals.find(t =>
+        t.name.toLowerCase().includes('opencode')
+      );
+    }
+
+    if (terminal) {
+      this.logger?.info(`[focusTerminal] Found terminal: "${terminal.name}", focusing...`);
+      // Focus the terminal (true = preserveFocus: false, meaning it takes focus)
+      terminal.show(true);
+      return true;
+    }
+
+    // No OpenCode terminal found
+    this.logger?.warn(`[focusTerminal] No OpenCode terminal found. Available: ${JSON.stringify(allTerminals)}`);
+    return false;
+  }
 }
 
 export default InstanceManager;

--- a/src/instance/instanceManager.ts
+++ b/src/instance/instanceManager.ts
@@ -649,34 +649,27 @@ export class InstanceManager {
   }
 
   /**
-   * Focus an existing OpenCode terminal by workspace hash
-   * @param workspaceHash - Optional workspace hash to find specific terminal
+   * Focus an existing OpenCode terminal
    * @returns Promise<boolean> - true if terminal was found and focused, false otherwise
    */
-  public async focusTerminal(workspaceHash?: string): Promise<boolean> {
+  public async focusTerminal(): Promise<boolean> {
     // Debug: log all available terminals
     const allTerminals = vscode.window.terminals.map(t => t.name);
     this.logger?.info(`[focusTerminal] Available terminals: ${JSON.stringify(allTerminals)}`);
 
     // Try multiple matching strategies
-    
+
     // 1. Match "OpenCode: <hash>" (the standard pattern from spawnInTerminal)
-    let terminal = vscode.window.terminals.find(t =>
-      t.name.startsWith('OpenCode: ')
-    );
+    let terminal = vscode.window.terminals.find(t => t.name.startsWith('OpenCode: '));
 
     // 2. Match "opencode" case-insensitively (for manually created terminals)
     if (!terminal) {
-      terminal = vscode.window.terminals.find(t =>
-        t.name.toLowerCase() === 'opencode'
-      );
+      terminal = vscode.window.terminals.find(t => t.name.toLowerCase() === 'opencode');
     }
 
     // 3. Match any terminal containing "opencode" (most permissive)
     if (!terminal) {
-      terminal = vscode.window.terminals.find(t =>
-        t.name.toLowerCase().includes('opencode')
-      );
+      terminal = vscode.window.terminals.find(t => t.name.toLowerCase().includes('opencode'));
     }
 
     if (terminal) {
@@ -687,7 +680,9 @@ export class InstanceManager {
     }
 
     // No OpenCode terminal found
-    this.logger?.warn(`[focusTerminal] No OpenCode terminal found. Available: ${JSON.stringify(allTerminals)}`);
+    this.logger?.warn(
+      `[focusTerminal] No OpenCode terminal found. Available: ${JSON.stringify(allTerminals)}`
+    );
     return false;
   }
 }


### PR DESCRIPTION
## Summary
- Add new config option `opencode.autoFocusTerminal` (default: true) to control terminal auto-focus behavior
- Add `focusTerminal()` method to InstanceManager that finds and focuses OpenCode terminals
- Auto-focus terminal after sending prompts via `addToPrompt`, `explainAndFix`, and `explainAndFixDiagnostic` commands
- Fix TypeScript narrowing issue by capturing outputChannel in const before passing to callbacks

## Changes
- **package.json**: Add `opencode.autoFocusTerminal` configuration
- **src/config.ts**: Add `getAutoFocusTerminal()` method
- **src/extension.ts**: Auto-focus terminal after prompt operations
- **src/instance/instanceManager.ts**: Add `focusTerminal()` method with multiple matching strategies