### PR TITLE
refactor: split extension.ts into modular components

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,15 +25,19 @@
     "commands": [
       {
         "command": "opencodeConnector.addToPrompt",
-        "title": "OpenCodeConnector: Add to Prompt"
+        "title": "OpenCode: Add to Prompt"
       },
       {
-        "command": "opencodeConnector.explainAndFix",
-        "title": "Explain and Fix (OpenCode)"
+        "command": "opencodeConnector.addMultipleFiles",
+        "title": "OpenCode: Select Files to Add"
       },
       {
-        "command": "opencode.explainAndFix",
-        "title": "Explain and Fix (OpenCode)"
+        "command": "opencodeConnector.checkInstance",
+        "title": "OpenCode: Check Instance"
+      },
+      {
+        "command": "opencodeConnector.showWorkspace",
+        "title": "OpenCode: Show Workspace"
       }
     ],
     "keybindings": [

--- a/src/commands/addMultipleFiles.ts
+++ b/src/commands/addMultipleFiles.ts
@@ -1,0 +1,86 @@
+import { ConnectionService } from '../connection/connectionService';
+
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+function showTransientNotification(message: string): void {
+  vscode.window.setStatusBarMessage(`$(check) ${message}`, 3000);
+}
+
+export async function handleAddMultipleFiles(
+  connectionService: ConnectionService,
+  outputChannel: vscode.LogOutputChannel
+): Promise<void> {
+  const allTabs = vscode.window.tabGroups.all.flatMap(group => group.tabs);
+
+  const textEditorTabs = allTabs.filter(
+    (tab): tab is vscode.Tab => tab.input instanceof vscode.TabInputText
+  );
+
+  if (textEditorTabs.length === 0) {
+    await vscode.window.showInformationMessage('No open editor tabs found');
+    return;
+  }
+
+  const items: vscode.QuickPickItem[] = textEditorTabs.map(tab => {
+    const input = tab.input as vscode.TabInputText;
+    const uri = input.uri;
+    const fileName = vscode.workspace.asRelativePath(uri, false);
+    const fullPath = uri.fsPath;
+
+    const dirMatch = fileName.match(/^(.+?)[/\\][^/\\]+$/);
+    const description = dirMatch ? dirMatch[1] + '/' : '';
+
+    return {
+      label: path.basename(fileName),
+      description: description,
+      detail: fullPath,
+      picked: true,
+    };
+  });
+
+  const selected = await vscode.window.showQuickPick(items, {
+    canPickMany: true,
+    placeHolder: 'Select files to add to prompt',
+    matchOnDescription: true,
+    matchOnDetail: true,
+    title: 'Select Files to Add to OpenCode',
+  });
+
+  if (!selected || selected.length === 0) {
+    return;
+  }
+
+  const connected = await connectionService.ensureConnected();
+  const openCodeClient = connectionService.getClient();
+  const lastAutoSpawnError = connectionService.getLastAutoSpawnError();
+
+  if (!connected || !openCodeClient) {
+    const msg = lastAutoSpawnError
+      ? `OpenCode auto-spawn failed: ${lastAutoSpawnError}`
+      : 'No OpenCode instance found. Run `opencode --port <port>` in your project directory.';
+    await vscode.window.showErrorMessage(msg);
+    return;
+  }
+
+  try {
+    const port = openCodeClient.getPort();
+    const workspaceDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || 'unknown';
+    outputChannel.info(`[addMultipleFiles] Sending to port ${port}, cwd: ${workspaceDir}`);
+
+    const refs = selected
+      .map(item => {
+        const relativePath = (item.description || '') + item.label;
+        return `@${relativePath}`;
+      })
+      .join(' ');
+
+    outputChannel.debug(`[addMultipleFiles] Sending: "${refs}"`);
+    await openCodeClient.appendPrompt(refs);
+
+    outputChannel.debug(`[addMultipleFiles] Sent ${selected.length} files`);
+    showTransientNotification(`Sent ${selected.length} files to OpenCode`);
+  } catch (err) {
+    await vscode.window.showErrorMessage(`Failed to send references: ${(err as Error).message}`);
+  }
+}

--- a/src/commands/addToPrompt.ts
+++ b/src/commands/addToPrompt.ts
@@ -1,0 +1,56 @@
+import { ConnectionService } from '../connection/connectionService';
+import { WorkspaceUtils } from '../utils/workspace';
+
+import * as vscode from 'vscode';
+
+function showTransientNotification(message: string): void {
+  vscode.window.setStatusBarMessage(`$(check) ${message}`, 3000);
+}
+
+export async function handleAddToPrompt(
+  connectionService: ConnectionService,
+  outputChannel: vscode.LogOutputChannel
+): Promise<void> {
+  const ref = WorkspaceUtils.getActiveFileRef();
+  if (!ref) {
+    await vscode.window.showWarningMessage('No active file to reference');
+    return;
+  }
+
+  const connected = await connectionService.ensureConnected();
+  const openCodeClient = connectionService.getClient();
+  const lastAutoSpawnError = connectionService.getLastAutoSpawnError();
+
+  if (!connected || !openCodeClient) {
+    const msg = lastAutoSpawnError
+      ? `OpenCode auto-spawn failed: ${lastAutoSpawnError}`
+      : 'No OpenCode instance found. Run `opencode --port <port>` in your project directory.';
+    await vscode.window.showErrorMessage(msg);
+    return;
+  }
+
+  try {
+    const port = openCodeClient.getPort();
+    const workspaceDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || 'unknown';
+    outputChannel.info(`[addToPrompt] Sending to port ${port}, cwd: ${workspaceDir}`);
+    outputChannel.debug(`[addToPrompt] Content: "${ref}"`);
+    const result = await openCodeClient.appendPrompt(ref);
+    outputChannel.debug(`[addToPrompt] Result: ${result}`);
+    showTransientNotification(`Sent: ${ref}`);
+
+    const configManager = connectionService.getConfigManager();
+    if (configManager.getAutoFocusTerminal()) {
+      outputChannel.debug(`[addToPrompt] Auto-focus enabled, attempting to focus terminal`);
+      try {
+        const focused = await connectionService.focusTerminal();
+        outputChannel.debug(`[addToPrompt] Terminal focus result: ${focused}`);
+      } catch (err) {
+        outputChannel.warn(`[addToPrompt] Terminal focus error: ${(err as Error).message}`);
+      }
+    } else {
+      outputChannel.debug(`[addToPrompt] Auto-focus disabled in config`);
+    }
+  } catch (err) {
+    await vscode.window.showErrorMessage(`Failed to send reference: ${(err as Error).message}`);
+  }
+}

--- a/src/commands/checkInstance.ts
+++ b/src/commands/checkInstance.ts
@@ -2,10 +2,7 @@ import { ConnectionService } from '../connection/connectionService';
 
 import * as vscode from 'vscode';
 
-export async function handleCheckInstance(
-  connectionService: ConnectionService,
-  _outputChannel: vscode.LogOutputChannel
-): Promise<void> {
+export async function handleCheckInstance(connectionService: ConnectionService): Promise<void> {
   const configManager = connectionService.getConfigManager();
   const port = configManager?.getPort() || 4096;
   const result = await connectionService.getRunningInstance(port);

--- a/src/commands/checkInstance.ts
+++ b/src/commands/checkInstance.ts
@@ -1,0 +1,30 @@
+import { ConnectionService } from '../connection/connectionService';
+
+import * as vscode from 'vscode';
+
+export async function handleCheckInstance(
+  connectionService: ConnectionService,
+  _outputChannel: vscode.LogOutputChannel
+): Promise<void> {
+  const configManager = connectionService.getConfigManager();
+  const port = configManager?.getPort() || 4096;
+  const result = await connectionService.getRunningInstance(port);
+
+  if (result.isRunning) {
+    await vscode.window.showInformationMessage(`OpenCode instance running on port ${port}`);
+  } else {
+    const choice = await vscode.window.showWarningMessage(
+      `No OpenCode instance detected on port ${port}`,
+      'Start Instance'
+    );
+
+    if (choice === 'Start Instance') {
+      const spawnResult = await connectionService.spawnInstance(port);
+      if (spawnResult.success) {
+        await vscode.window.showInformationMessage('OpenCode instance started');
+      } else {
+        await vscode.window.showErrorMessage(`Failed to start instance: ${spawnResult.error}`);
+      }
+    }
+  }
+}

--- a/src/commands/explainAndFix.ts
+++ b/src/commands/explainAndFix.ts
@@ -1,0 +1,46 @@
+import { ConnectionService } from '../connection/connectionService';
+import { formatPromptForDiagnostic } from '../providers/codeActionProvider';
+
+import * as vscode from 'vscode';
+
+function showTransientNotification(message: string): void {
+  vscode.window.setStatusBarMessage(`$(check) ${message}`, 3000);
+}
+
+export async function handleExplainAndFix(
+  connectionService: ConnectionService,
+  outputChannel: vscode.LogOutputChannel,
+  diagnostic: vscode.Diagnostic,
+  uri: vscode.Uri
+): Promise<void> {
+  const connected = await connectionService.ensureConnected();
+  const openCodeClient = connectionService.getClient();
+  const lastAutoSpawnError = connectionService.getLastAutoSpawnError();
+
+  if (!connected || !openCodeClient) {
+    const msg = lastAutoSpawnError
+      ? `OpenCode auto-spawn failed: ${lastAutoSpawnError}`
+      : 'No OpenCode instance found. Run `opencode --port <port>` in your project directory.';
+    await vscode.window.showErrorMessage(msg);
+    return;
+  }
+
+  try {
+    const prompt = formatPromptForDiagnostic(diagnostic, uri, uriInfo =>
+      vscode.workspace.asRelativePath(uriInfo.fsPath)
+    );
+    await openCodeClient.appendPrompt(prompt);
+    showTransientNotification(`Sent explanation request for diagnostic`);
+
+    const configManager = connectionService.getConfigManager();
+    if (configManager.getAutoFocusTerminal()) {
+      try {
+        await connectionService.focusTerminal();
+      } catch {
+        // Silently ignore focus errors
+      }
+    }
+  } catch (err) {
+    await vscode.window.showErrorMessage(`Failed to send explanation: ${(err as Error).message}`);
+  }
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,0 +1,5 @@
+export { handleCheckInstance } from './checkInstance';
+export { handleShowWorkspace } from './showWorkspace';
+export { handleAddToPrompt } from './addToPrompt';
+export { handleAddMultipleFiles } from './addMultipleFiles';
+export { handleExplainAndFix } from './explainAndFix';

--- a/src/commands/showWorkspace.ts
+++ b/src/commands/showWorkspace.ts
@@ -1,0 +1,18 @@
+import { ConnectionService } from '../connection/connectionService';
+import { WorkspaceUtils } from '../utils/workspace';
+
+import * as vscode from 'vscode';
+
+export async function handleShowWorkspace(
+  _connectionService: ConnectionService,
+  _outputChannel: vscode.LogOutputChannel
+): Promise<void> {
+  const workspaceInfo = WorkspaceUtils.detectWorkspace();
+  const name = WorkspaceUtils.getWorkspaceName();
+  const roots = workspaceInfo.rootCount;
+
+  const message =
+    `Workspace: ${name}\n` + `Roots: ${roots}\n` + `Multi-root: ${roots > 1 ? 'Yes' : 'No'}`;
+
+  await vscode.window.showInformationMessage(message);
+}

--- a/src/commands/showWorkspace.ts
+++ b/src/commands/showWorkspace.ts
@@ -1,12 +1,8 @@
-import { ConnectionService } from '../connection/connectionService';
 import { WorkspaceUtils } from '../utils/workspace';
 
 import * as vscode from 'vscode';
 
-export async function handleShowWorkspace(
-  _connectionService: ConnectionService,
-  _outputChannel: vscode.LogOutputChannel
-): Promise<void> {
+export async function handleShowWorkspace(): Promise<void> {
   const workspaceInfo = WorkspaceUtils.detectWorkspace();
   const name = WorkspaceUtils.getWorkspaceName();
   const roots = workspaceInfo.rootCount;

--- a/src/connection/connectionService.ts
+++ b/src/connection/connectionService.ts
@@ -1,0 +1,366 @@
+import { OpenCodeClient } from '../api/openCodeClient';
+import { ConfigManager } from '../config';
+import { InstanceManager } from '../instance/instanceManager';
+
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+/**
+ * Logger interface for output channel
+ */
+interface Logger {
+  debug(message: string): void;
+  info(message: string): void;
+  warn(message: string): void;
+  error(message: string): void;
+}
+
+/**
+ * Connection Service for OpenCode
+ * Manages connection lifecycle: discovery, auto-spawn, and fallback
+ */
+export class ConnectionService {
+  private client: OpenCodeClient | undefined;
+  private connectedPort: number | undefined;
+  private lastAutoSpawnError: string | undefined;
+
+  private configManager: ConfigManager;
+  private instanceManager: InstanceManager;
+  private outputChannel: Logger | undefined;
+
+  constructor(
+    configManager: ConfigManager,
+    instanceManager: InstanceManager,
+    outputChannel?: Logger
+  ) {
+    this.configManager = configManager;
+    this.instanceManager = instanceManager;
+    this.outputChannel = outputChannel;
+  }
+
+  /**
+   * Discover a running OpenCode instance serving the current workspace directory.
+   * Scans running processes, verifies each with GET /path, and matches against workspace CWD.
+   * If a match is found, creates/updates the global client to use that port.
+   * @param delayMs - Delay between retries in ms (default: 2000)
+   * @returns true if connected, false if no matching instance found
+   */
+  async discoverAndConnect(retries: number = 3, delayMs: number = 2000): Promise<boolean> {
+    // Get the workspace directory to match against
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    if (!workspaceFolders || workspaceFolders.length === 0) {
+      return false;
+    }
+    const workspaceDir = workspaceFolders[0].uri.fsPath;
+
+    for (let attempt = 1; attempt <= retries; attempt++) {
+      if (attempt > 1) {
+        this.outputChannel?.info(
+          `[discoverAndConnect] Retry ${attempt}/${retries} after ${delayMs}ms delay...`
+        );
+        await new Promise(resolve => setTimeout(resolve, delayMs));
+      }
+
+      // Scan for running opencode processes
+      const processes = await this.instanceManager.scanForProcesses();
+      this.outputChannel?.info(
+        `[discoverAndConnect] Attempt ${attempt}: Found ${processes.length} OpenCode process(es): ${processes.map(p => p.port).join(', ')}`
+      );
+
+      if (processes.length === 0) {
+        // No processes found, try again (server may be starting)
+        continue;
+      }
+
+      // Deduplicate ports
+      const uniquePorts = [...new Set(processes.map(p => p.port))];
+
+      // Track if any process matched our workspace
+      let foundMatchingProcess = false;
+
+      // For each port, verify it's an OpenCode server serving our directory
+      for (const port of uniquePorts) {
+        try {
+          this.outputChannel?.debug(`[discoverAndConnect] Checking port ${port}...`);
+          const tempClient = new OpenCodeClient({ port, timeout: 3000, maxRetries: 0 });
+          const pathInfo = await tempClient.getPath();
+          tempClient.destroy();
+
+          this.outputChannel?.debug(
+            `[discoverAndConnect] Port ${port} server dir: "${pathInfo.directory}" vs workspace: "${workspaceDir}"`
+          );
+
+          const matches = pathsMatch(pathInfo.directory, workspaceDir);
+          this.outputChannel?.debug(`[discoverAndConnect] Paths match: ${matches}`);
+
+          // Normalize paths for comparison (platform-aware)
+          if (matches) {
+            foundMatchingProcess = true;
+            // Found a match — update the global client
+            if (this.connectedPort !== port) {
+              if (this.client) {
+                this.client.destroy();
+              }
+              this.client = new OpenCodeClient({ port });
+              this.connectedPort = port;
+
+              this.outputChannel?.info(
+                `OpenCode Connector: auto-connected to instance on port ${port}`
+              );
+            }
+            return true;
+          }
+        } catch (err) {
+          // This port isn't a valid OpenCode server, skip
+          this.outputChannel?.warn(
+            `[discoverAndConnect] Port ${port} error: ${(err as Error).message}`
+          );
+          continue;
+        }
+      }
+
+      // If processes were found but none matched our workspace, no point retrying
+      if (!foundMatchingProcess) {
+        this.outputChannel?.info(
+          '[discoverAndConnect] Processes found but none match workspace, giving up'
+        );
+        break;
+      }
+    }
+
+    // Exhausted all retries
+    this.outputChannel?.info(
+      '[discoverAndConnect] No OpenCode processes found after retries, will attempt auto-spawn'
+    );
+    return false;
+  }
+
+  /**
+   * Wait for the OpenCode server to be ready on a specific port
+   * @param port - Port to check
+   * @param retries - Number of retry attempts (default: 30)
+   * @param delay - Delay between retries in ms (default: 1000)
+   * @returns true if server is ready, false if timeout
+   */
+  async waitForServer(port: number, retries: number = 30, delay: number = 1000): Promise<boolean> {
+    for (let attempt = 1; attempt <= retries; attempt++) {
+      try {
+        // Create a temporary client to test the server
+        const tempClient = new OpenCodeClient({ port, timeout: 1000, maxRetries: 0 });
+
+        // Use getPath() as a health check (it tests the /path endpoint)
+        await tempClient.getPath();
+        tempClient.destroy();
+
+        // Server is ready
+        return true;
+      } catch {
+        // Server not ready yet, wait and retry
+        if (attempt < retries) {
+          await new Promise(resolve => setTimeout(resolve, delay));
+        }
+      }
+    }
+
+    // Timeout - server never became ready
+    return false;
+  }
+
+  /**
+   * Ensure we're connected to an OpenCode instance.
+   * Tries: current client → auto-discovery → auto-spawn → configured port.
+   * @returns true if connected
+   */
+  async ensureConnected(): Promise<boolean> {
+    // 1. Check if current client is still alive AND serving the correct workspace
+    if (this.client) {
+      try {
+        const connected = await this.client.testConnection();
+        if (connected) {
+          // Client is alive — verify it's serving the current workspace
+          const workspaceFolders = vscode.workspace.workspaceFolders;
+          if (workspaceFolders && workspaceFolders.length > 0) {
+            const currentWorkspaceDir = workspaceFolders[0].uri.fsPath;
+            const pathInfo = await this.client.getPath();
+            if (pathsMatch(pathInfo.directory, currentWorkspaceDir)) {
+              return true; // Client is alive and serving correct workspace
+            }
+            // Client is alive but serving wrong workspace — destroy and re-discover
+            this.client.destroy();
+            this.client = undefined;
+            this.connectedPort = undefined;
+          }
+        }
+      } catch {
+        // Current client is dead, try discovery
+      }
+    }
+
+    // 2. Auto-discover from running processes
+    const discovered = await this.discoverAndConnect();
+    if (discovered) {
+      return true;
+    }
+
+    // 3. Auto-spawn new instance if discovery failed
+    this.lastAutoSpawnError = undefined;
+    try {
+      // Find an available port
+      const port = await this.instanceManager.findAvailablePort();
+
+      // Spawn in terminal
+      await this.instanceManager.spawnInTerminal(port);
+
+      // Wait for server to be ready
+      const serverReady = await this.waitForServer(port);
+
+      if (serverReady) {
+        // Additional settling delay — the HTTP server responds before the TUI
+        // is fully initialized. Without this, the first appendPrompt is dropped.
+        await new Promise(resolve => setTimeout(resolve, 2000));
+
+        // Update the client to use the new port
+        if (this.client) {
+          this.client.destroy();
+        }
+        this.client = new OpenCodeClient({ port });
+        this.connectedPort = port;
+
+        this.outputChannel?.info(
+          `OpenCode Connector: spawned and connected to instance on port ${port}`
+        );
+        return true;
+      } else {
+        this.lastAutoSpawnError = `Spawned OpenCode on port ${port} but it did not become ready within 30s. Check the "OpenCode" terminal for errors.`;
+      }
+    } catch (err) {
+      this.lastAutoSpawnError = `Auto-spawn failed: ${(err as Error).message}`;
+      // Continue to fallback
+    }
+
+    // 4. Fall back to configured port
+    const port = this.configManager.getPort() ?? 4096;
+    if (!this.client || this.client.getPort() !== port) {
+      if (this.client) {
+        this.client.destroy();
+      }
+      this.client = new OpenCodeClient({ port });
+      this.connectedPort = port;
+    }
+
+    // Test the fallback
+    try {
+      return await this.client.testConnection();
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Get the current OpenCodeClient instance
+   * @returns The current client or undefined
+   */
+  getClient(): OpenCodeClient | undefined {
+    return this.client;
+  }
+
+  /**
+   * Get the currently connected port
+   * @returns The current port or undefined
+   */
+  getPort(): number | undefined {
+    return this.connectedPort;
+  }
+
+  /**
+   * Get the last auto-spawn error message
+   * @returns Error message or undefined
+   */
+  getLastAutoSpawnError(): string | undefined {
+    return this.lastAutoSpawnError;
+  }
+
+  /**
+   * Check if an OpenCode instance is running on a specific port
+   * @param port - Port to check
+   * @returns Result indicating if instance is running
+   */
+  async getRunningInstance(port: number): Promise<{ isRunning: boolean; pid?: number }> {
+    return this.instanceManager.getRunningInstance(port);
+  }
+
+  /**
+   * Spawn a new OpenCode instance
+   * @param port - Port to run the instance on
+   * @returns Result indicating success or error
+   */
+  async spawnInstance(port: number): Promise<{ success: boolean; error?: string }> {
+    return this.instanceManager.spawnInstance(port);
+  }
+
+  /**
+   * Get the InstanceManager instance
+   * @returns The instance manager
+   */
+  getInstanceManager(): InstanceManager {
+    return this.instanceManager;
+  }
+
+  /**
+   * Get the ConfigManager instance
+   * @returns The config manager
+   */
+  getConfigManager(): ConfigManager {
+    return this.configManager;
+  }
+
+  /**
+   * Focus the integrated terminal
+   * @returns true if successful
+   */
+  async focusTerminal(): Promise<boolean> {
+    return this.instanceManager.focusTerminal();
+  }
+}
+
+/**
+ * Check if running in a remote session (SSH, WSL, Containers, Dev Pods)
+ * @returns true if running in a remote environment
+ */
+export function isRemoteSession(): boolean {
+  return vscode.env.remoteName !== undefined;
+}
+
+/**
+ * Normalize and compare filesystem paths across platforms.
+ * Handles: path separators, trailing slashes, remote path formats.
+ * @param serverPath - Path returned by OpenCode server
+ * @param localPath - Path from VSCode workspace
+ * @returns true if paths refer to the same directory
+ */
+export function pathsMatch(serverPath: string, localPath: string): boolean {
+  // Normalize: resolve to absolute, remove trailing separators, lowercase if case-insensitive
+  const normalize = (p: string): string => {
+    // Resolve relative paths to absolute (handles "." and "./")
+    let resolved = path.resolve(p);
+    // Normalize separators to platform default
+    resolved = path.normalize(resolved);
+    // Remove trailing slashes
+    resolved = resolved.replace(/[\\/]+$/, '');
+    return resolved;
+  };
+
+  const normalizedServer = normalize(serverPath);
+  const normalizedLocal = normalize(localPath);
+
+  // On case-insensitive filesystems (Windows, macOS), use case-insensitive comparison
+  // On case-sensitive filesystems (Linux, most remote servers), use case-sensitive comparison
+  const isCaseSensitive = process.platform !== 'win32' && process.platform !== 'darwin';
+
+  if (isCaseSensitive) {
+    return normalizedServer === normalizedLocal;
+  }
+  return normalizedServer.toLowerCase() === normalizedLocal.toLowerCase();
+}
+
+export default ConnectionService;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -135,13 +135,13 @@ function registerCommands(): void {
   // Check instance status command
   const statusCommand = vscode.commands.registerCommand(
     'opencodeConnector.checkInstance',
-    async () => handleCheckInstance(connectionService!, outputChannel!)
+    async () => handleCheckInstance(connectionService!)
   );
 
   // Show workspace info command
   const workspaceCommand = vscode.commands.registerCommand(
     'opencodeConnector.showWorkspace',
-    async () => handleShowWorkspace(connectionService!, outputChannel!)
+    async () => handleShowWorkspace()
   );
 
   // Add file reference to OpenCode prompt
@@ -156,13 +156,12 @@ function registerCommands(): void {
     async () => handleAddMultipleFiles(connectionService!, outputChannel!)
   );
 
-
   // Push all subscriptions for cleanup
   extensionContext?.subscriptions.push(
     statusCommand,
     workspaceCommand,
     addFileCommand,
-    addMultipleFilesCommand,
+    addMultipleFilesCommand
   );
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -164,45 +164,13 @@ function registerCommands(): void {
       handleExplainAndFix(connectionService!, outputChannel!, diagnostic, uri)
   );
 
-  // Alias commands with 'opencode.' prefix for compatibility
-  const opencodeCheckInstanceCommand = vscode.commands.registerCommand(
-    'opencode.checkInstance',
-    async () => handleCheckInstance(connectionService!, outputChannel!)
-  );
-
-  const opencodeShowWorkspaceCommand = vscode.commands.registerCommand(
-    'opencode.showWorkspace',
-    async () => handleShowWorkspace(connectionService!, outputChannel!)
-  );
-
-  const opencodeAddToPromptCommand = vscode.commands.registerCommand(
-    'opencode.addToPrompt',
-    async () => handleAddToPrompt(connectionService!, outputChannel!)
-  );
-
-  const opencodeAddMultipleFilesCommand = vscode.commands.registerCommand(
-    'opencode.addMultipleFiles',
-    async () => handleAddMultipleFiles(connectionService!, outputChannel!)
-  );
-
-  const opencodeExplainAndFixCommand = vscode.commands.registerCommand(
-    'opencode.explainAndFix',
-    async (diagnostic: vscode.Diagnostic, uri: vscode.Uri) =>
-      handleExplainAndFix(connectionService!, outputChannel!, diagnostic, uri)
-  );
-
   // Push all subscriptions for cleanup
   extensionContext?.subscriptions.push(
     statusCommand,
     workspaceCommand,
     addFileCommand,
     addMultipleFilesCommand,
-    explainAndFixCommand,
-    opencodeCheckInstanceCommand,
-    opencodeShowWorkspaceCommand,
-    opencodeAddToPromptCommand,
-    opencodeAddMultipleFilesCommand,
-    opencodeExplainAndFixCommand
+    explainAndFixCommand
   );
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,301 +2,31 @@
  * OpenCode Connector VSCode Extension
  * Provides integration between VS Code and OpenCode AI assistant
  */
-import { OpenCodeClient } from './api/openCodeClient';
+import {
+  handleAddMultipleFiles,
+  handleAddToPrompt,
+  handleCheckInstance,
+  handleExplainAndFix,
+  handleShowWorkspace,
+} from './commands';
 import { ConfigManager } from './config';
+import { ConnectionService, isRemoteSession } from './connection/connectionService';
 import { ContextManager } from './context/contextManager';
 import { InstanceManager } from './instance/instanceManager';
-import {
-  OpenCodeCodeActionProvider,
-  formatPromptForDiagnostic,
-} from './providers/codeActionProvider';
+import { OpenCodeCodeActionProvider } from './providers/codeActionProvider';
 import { WorkspaceUtils } from './utils/workspace';
 
-import * as path from 'path';
 import * as vscode from 'vscode';
-
-/**
- * Check if running in a remote session (SSH, WSL, Containers, Dev Pods)
- * @returns true if running in a remote environment
- */
-function isRemoteSession(): boolean {
-  return vscode.env.remoteName !== undefined;
-}
-
-/**
- * Normalize and compare filesystem paths across platforms.
- * Handles: path separators, trailing slashes, remote path formats.
- * @param serverPath - Path returned by OpenCode server
- * @param localPath - Path from VSCode workspace
- * @returns true if paths refer to the same directory
- */
-function pathsMatch(serverPath: string, localPath: string): boolean {
-  // Normalize: resolve to absolute, remove trailing separators, lowercase if case-insensitive
-  const normalize = (p: string): string => {
-    // Resolve relative paths to absolute (handles "." and "./")
-    let resolved = path.resolve(p);
-    // Normalize separators to platform default
-    resolved = path.normalize(resolved);
-    // Remove trailing slashes
-    resolved = resolved.replace(/[\\/]+$/, '');
-    return resolved;
-  };
-
-  const normalizedServer = normalize(serverPath);
-  const normalizedLocal = normalize(localPath);
-
-  // On case-insensitive filesystems (Windows, macOS), use case-insensitive comparison
-  // On case-sensitive filesystems (Linux, most remote servers), use case-sensitive comparison
-  const isCaseSensitive = process.platform !== 'win32' && process.platform !== 'darwin';
-
-  if (isCaseSensitive) {
-    return normalizedServer === normalizedLocal;
-  }
-  return normalizedServer.toLowerCase() === normalizedLocal.toLowerCase();
-}
 
 /**
  * Global extension state
  */
 let configManager: ConfigManager | undefined;
-let openCodeClient: OpenCodeClient | undefined;
-let instanceManager: InstanceManager | undefined;
+let connectionService: ConnectionService | undefined;
 let contextManager: ContextManager | undefined;
 let extensionContext: vscode.ExtensionContext | undefined;
-/** Port of the currently connected OpenCode instance */
-let connectedPort: number | undefined;
-/** Last auto-spawn error for user-facing messages */
-let lastAutoSpawnError: string | undefined;
-/** Status bar item for transient notifications */
 let statusBarItem: vscode.StatusBarItem | undefined;
-/** Log output channel for extension logs */
 let outputChannel: vscode.LogOutputChannel | undefined;
-
-/**
- * Discover a running OpenCode instance serving the current workspace directory.
- * Scans running processes, verifies each with GET /path, and matches against workspace CWD.
- * If a match is found, creates/updates the global client to use that port.
- * @param retries - Number of retry attempts (default: 3)
- * @param delayMs - Delay between retries in ms (default: 2000)
- * @returns true if connected, false if no matching instance found
- */
-async function discoverAndConnect(retries: number = 3, delayMs: number = 2000): Promise<boolean> {
-  if (!instanceManager) {
-    return false;
-  }
-
-  // Get the workspace directory to match against
-  const workspaceFolders = vscode.workspace.workspaceFolders;
-  if (!workspaceFolders || workspaceFolders.length === 0) {
-    return false;
-  }
-  const workspaceDir = workspaceFolders[0].uri.fsPath;
-
-  for (let attempt = 1; attempt <= retries; attempt++) {
-    if (attempt > 1) {
-      outputChannel?.info(
-        `[discoverAndConnect] Retry ${attempt}/${retries} after ${delayMs}ms delay...`
-      );
-      await new Promise(resolve => setTimeout(resolve, delayMs));
-    }
-
-    // Scan for running opencode processes
-    const processes = await instanceManager.scanForProcesses();
-    outputChannel?.info(
-      `[discoverAndConnect] Attempt ${attempt}: Found ${processes.length} OpenCode process(es): ${processes.map(p => p.port).join(', ')}`
-    );
-
-    if (processes.length === 0) {
-      // No processes found, try again (server may be starting)
-      continue;
-    }
-
-    // Deduplicate ports
-    const uniquePorts = [...new Set(processes.map(p => p.port))];
-
-    // Track if any process matched our workspace
-    let foundMatchingProcess = false;
-
-    // For each port, verify it's an OpenCode server serving our directory
-    for (const port of uniquePorts) {
-      try {
-        outputChannel?.debug(`[discoverAndConnect] Checking port ${port}...`);
-        const tempClient = new OpenCodeClient({ port, timeout: 3000, maxRetries: 0 });
-        const pathInfo = await tempClient.getPath();
-        tempClient.destroy();
-
-        outputChannel?.debug(
-          `[discoverAndConnect] Port ${port} server dir: "${pathInfo.directory}" vs workspace: "${workspaceDir}"`
-        );
-
-        const matches = pathsMatch(pathInfo.directory, workspaceDir);
-        outputChannel?.debug(`[discoverAndConnect] Paths match: ${matches}`);
-
-        // Normalize paths for comparison (platform-aware)
-        if (matches) {
-          foundMatchingProcess = true;
-          // Found a match — update the global client
-          if (connectedPort !== port) {
-            if (openCodeClient) {
-              openCodeClient.destroy();
-            }
-            openCodeClient = new OpenCodeClient({ port });
-            connectedPort = port;
-
-            outputChannel?.info(`OpenCode Connector: auto-connected to instance on port ${port}`);
-          }
-          return true;
-        }
-      } catch (err) {
-        // This port isn't a valid OpenCode server, skip
-        outputChannel?.warn(`[discoverAndConnect] Port ${port} error: ${(err as Error).message}`);
-        continue;
-      }
-    }
-
-    // If processes were found but none matched our workspace, no point retrying
-    // (unless a new instance happens to spawn mid-delay, which is unlikely)
-    if (!foundMatchingProcess) {
-      outputChannel?.info(
-        '[discoverAndConnect] Processes found but none match workspace, giving up'
-      );
-      break;
-    }
-  }
-
-  // Exhausted all retries
-  outputChannel?.info(
-    '[discoverAndConnect] No OpenCode processes found after retries, will attempt auto-spawn'
-  );
-  return false;
-}
-
-/**
- * Ensure we're connected to an OpenCode instance.
- * Tries: current client → auto-discovery → auto-spawn → configured port.
- * @returns true if connected
- */
-async function ensureConnected(): Promise<boolean> {
-  // 1. Check if current client is still alive AND serving the correct workspace
-  if (openCodeClient) {
-    try {
-      const connected = await openCodeClient.testConnection();
-      if (connected) {
-        // Client is alive — verify it's serving the current workspace
-        const workspaceFolders = vscode.workspace.workspaceFolders;
-        if (workspaceFolders && workspaceFolders.length > 0) {
-          const currentWorkspaceDir = workspaceFolders[0].uri.fsPath;
-          const pathInfo = await openCodeClient.getPath();
-          if (pathsMatch(pathInfo.directory, currentWorkspaceDir)) {
-            return true; // Client is alive and serving correct workspace
-          }
-          // Client is alive but serving wrong workspace — destroy and re-discover
-          openCodeClient.destroy();
-          openCodeClient = undefined;
-          connectedPort = undefined;
-        }
-      }
-    } catch {
-      // Current client is dead, try discovery
-    }
-  }
-
-  // 2. Auto-discover from running processes
-  const discovered = await discoverAndConnect();
-  if (discovered) {
-    return true;
-  }
-
-  // 3. Auto-spawn new instance if discovery failed
-  lastAutoSpawnError = undefined;
-  if (instanceManager) {
-    try {
-      // Find an available port
-      const port = await instanceManager.findAvailablePort();
-
-      // Spawn in terminal
-      await instanceManager.spawnInTerminal(port);
-
-      // Wait for server to be ready
-      const serverReady = await waitForServer(port);
-
-      if (serverReady) {
-        // Additional settling delay — the HTTP server responds before the TUI
-        // is fully initialized. Without this, the first appendPrompt is dropped.
-        await new Promise(resolve => setTimeout(resolve, 2000));
-
-        // Update the client to use the new port
-        if (openCodeClient) {
-          openCodeClient.destroy();
-        }
-        openCodeClient = new OpenCodeClient({ port });
-        connectedPort = port;
-
-        outputChannel?.info(
-          `OpenCode Connector: spawned and connected to instance on port ${port}`
-        );
-        return true;
-      } else {
-        lastAutoSpawnError = `Spawned OpenCode on port ${port} but it did not become ready within 30s. Check the "OpenCode" terminal for errors.`;
-      }
-    } catch (err) {
-      lastAutoSpawnError = `Auto-spawn failed: ${(err as Error).message}`;
-      // Continue to fallback
-    }
-  }
-
-  // 4. Fall back to configured port
-  const port = configManager?.getPort() ?? 4096;
-  if (!openCodeClient || openCodeClient.getPort() !== port) {
-    if (openCodeClient) {
-      openCodeClient.destroy();
-    }
-    openCodeClient = new OpenCodeClient({ port });
-    connectedPort = port;
-  }
-
-  // Test the fallback
-  try {
-    return await openCodeClient.testConnection();
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Wait for the OpenCode server to be ready on a specific port
- * @param port - Port to check
- * @param retries - Number of retry attempts (default: 30)
- * @param delay - Delay between retries in ms (default: 1000)
- * @returns true if server is ready, false if timeout
- */
-async function waitForServer(
-  port: number,
-  retries: number = 30,
-  delay: number = 1000
-): Promise<boolean> {
-  for (let attempt = 1; attempt <= retries; attempt++) {
-    try {
-      // Create a temporary client to test the server
-      const tempClient = new OpenCodeClient({ port, timeout: 1000, maxRetries: 0 });
-
-      // Use getPath() as a health check (it tests the /path endpoint)
-      await tempClient.getPath();
-      tempClient.destroy();
-
-      // Server is ready
-      return true;
-    } catch {
-      // Server not ready yet, wait and retry
-      if (attempt < retries) {
-        await new Promise(resolve => setTimeout(resolve, delay));
-      }
-    }
-  }
-
-  // Timeout - server never became ready
-  return false;
-}
 
 /**
  * Called when the extension is activated.
@@ -320,12 +50,8 @@ export function activate(extensionUri: vscode.Uri, context: vscode.ExtensionCont
     // Initialize configuration manager (singleton)
     configManager = ConfigManager.getInstance(extensionUri);
 
-    // Initialize OpenCode client
-    const port = configManager.getPort();
-    openCodeClient = new OpenCodeClient({ port });
-
     // Initialize instance manager (singleton)
-    instanceManager = InstanceManager.getInstance(configManager);
+    const instanceManager = InstanceManager.getInstance(configManager);
 
     // Set up logger for InstanceManager to use the OutputChannel
     if (outputChannel) {
@@ -336,6 +62,11 @@ export function activate(extensionUri: vscode.Uri, context: vscode.ExtensionCont
         error: (msg: string) => channel.error(msg),
       });
     }
+
+    // Initialize connection service
+    connectionService = new ConnectionService(configManager, instanceManager, outputChannel);
+
+    // Initialize context manager
 
     // Initialize context manager
     contextManager = new ContextManager({
@@ -380,7 +111,7 @@ export function activate(extensionUri: vscode.Uri, context: vscode.ExtensionCont
     registerWorkspaceHandlers();
 
     // Eagerly discover and connect in background so first command is instant
-    discoverAndConnect().catch(() => {
+    connectionService.discoverAndConnect().catch(() => {
       // Silently ignore — ensureConnected() will retry on-demand
     });
 
@@ -394,442 +125,85 @@ export function activate(extensionUri: vscode.Uri, context: vscode.ExtensionCont
   }
 }
 
-function showTransientNotification(message: string): void {
-  vscode.window.setStatusBarMessage(`$(check) ${message}`, 3000);
-}
-
 /**
  * Register VSCode commands
  */
 function registerCommands(): void {
+  if (!connectionService || !outputChannel) {
+    return;
+  }
+
   // Check instance status command
   const statusCommand = vscode.commands.registerCommand(
     'opencodeConnector.checkInstance',
-    async () => {
-      if (!instanceManager) {
-        await vscode.window.showErrorMessage('Instance manager not initialized');
-        return;
-      }
-
-      const port = configManager?.getPort() || 3000;
-      const result = await instanceManager.getRunningInstance(port);
-
-      if (result.isRunning) {
-        await vscode.window.showInformationMessage(`OpenCode instance running on port ${port}`);
-      } else {
-        const choice = await vscode.window.showWarningMessage(
-          `No OpenCode instance detected on port ${port}`,
-          'Start Instance'
-        );
-
-        if (choice === 'Start Instance' && instanceManager) {
-          const spawnResult = await instanceManager.spawnInstance(port);
-          if (spawnResult.success) {
-            await vscode.window.showInformationMessage('OpenCode instance started');
-          } else {
-            await vscode.window.showErrorMessage(`Failed to start instance: ${spawnResult.error}`);
-          }
-        }
-      }
-    }
+    async () => handleCheckInstance(connectionService!, outputChannel!)
   );
 
   // Show workspace info command
   const workspaceCommand = vscode.commands.registerCommand(
     'opencodeConnector.showWorkspace',
-    async () => {
-      const workspaceInfo = WorkspaceUtils.detectWorkspace();
-      const name = WorkspaceUtils.getWorkspaceName();
-      const roots = workspaceInfo.rootCount;
-
-      const message =
-        `Workspace: ${name}\n` + `Roots: ${roots}\n` + `Multi-root: ${roots > 1 ? 'Yes' : 'No'}`;
-
-      await vscode.window.showInformationMessage(message);
-    }
-  );
-
-  // Alias commands with 'opencode.' prefix (same handlers as 'opencodeConnector.' prefix)
-  const opencodeCheckInstanceCommand = vscode.commands.registerCommand(
-    'opencode.checkInstance',
-    async () => {
-      if (!instanceManager) {
-        await vscode.window.showErrorMessage('Instance manager not initialized');
-        return;
-      }
-
-      const port = configManager?.getPort() || 3000;
-      const result = await instanceManager.getRunningInstance(port);
-
-      if (result.isRunning) {
-        await vscode.window.showInformationMessage(`OpenCode instance running on port ${port}`);
-      } else {
-        const choice = await vscode.window.showWarningMessage(
-          `No OpenCode instance detected on port ${port}`,
-          'Start Instance'
-        );
-
-        if (choice === 'Start Instance' && instanceManager) {
-          const spawnResult = await instanceManager.spawnInstance(port);
-          if (spawnResult.success) {
-            await vscode.window.showInformationMessage('OpenCode instance started');
-          } else {
-            await vscode.window.showErrorMessage(`Failed to start instance: ${spawnResult.error}`);
-          }
-        }
-      }
-    }
-  );
-
-  const opencodeShowWorkspaceCommand = vscode.commands.registerCommand(
-    'opencode.showWorkspace',
-    async () => {
-      const workspaceInfo = WorkspaceUtils.detectWorkspace();
-      const name = WorkspaceUtils.getWorkspaceName();
-      const roots = workspaceInfo.rootCount;
-
-      const message =
-        `Workspace: ${name}\n` + `Roots: ${roots}\n` + `Multi-root: ${roots > 1 ? 'Yes' : 'No'}`;
-
-      await vscode.window.showInformationMessage(message);
-    }
+    async () => handleShowWorkspace(connectionService!, outputChannel!)
   );
 
   // Add file reference to OpenCode prompt
   const addFileCommand = vscode.commands.registerCommand(
     'opencodeConnector.addToPrompt',
-    async () => {
-      const ref = getActiveFileRef();
-      if (!ref) {
-        await vscode.window.showWarningMessage('No active file to reference');
-        return;
-      }
-
-      const connected = await ensureConnected();
-      if (!connected || !openCodeClient) {
-        const msg = lastAutoSpawnError
-          ? `OpenCode auto-spawn failed: ${lastAutoSpawnError}`
-          : 'No OpenCode instance found. Run `opencode --port <port>` in your project directory.';
-        await vscode.window.showErrorMessage(msg);
-        return;
-      }
-
-      try {
-        const port = openCodeClient.getPort();
-        const workspaceDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || 'unknown';
-        outputChannel?.info(`[addToPrompt] Sending to port ${port}, cwd: ${workspaceDir}`);
-        outputChannel?.debug(`[addToPrompt] Content: "${ref}"`);
-        const result = await openCodeClient.appendPrompt(ref);
-        outputChannel?.debug(`[addToPrompt] Result: ${result}`);
-        showTransientNotification(`Sent: ${ref}`);
-        // Auto-focus terminal if enabled
-        if (ConfigManager.getInstance().getAutoFocusTerminal()) {
-          outputChannel?.debug(`[addToPrompt] Auto-focus enabled, attempting to focus terminal`);
-          try {
-            const focused = await InstanceManager.getInstance().focusTerminal();
-            outputChannel?.debug(`[addToPrompt] Terminal focus result: ${focused}`);
-          } catch (err) {
-            outputChannel?.warn(`[addToPrompt] Terminal focus error: ${(err as Error).message}`);
-            // Silently ignore focus errors - don't fail the main operation
-          }
-        } else {
-          outputChannel?.debug(`[addToPrompt] Auto-focus disabled in config`);
-        }
-      } catch (err) {
-        await vscode.window.showErrorMessage(`Failed to send reference: ${(err as Error).message}`);
-      }
-    }
+    async () => handleAddToPrompt(connectionService!, outputChannel!)
   );
 
   // Multi-file picker command
   const addMultipleFilesCommand = vscode.commands.registerCommand(
     'opencodeConnector.addMultipleFiles',
-    async () => {
-      // Get all tabs from all tab groups
-      const allTabs = vscode.window.tabGroups.all.flatMap(group => group.tabs);
-
-      // Filter to only text editor tabs (TabInputText)
-      const textEditorTabs = allTabs.filter(
-        (tab): tab is vscode.Tab => tab.input instanceof vscode.TabInputText
-      );
-
-      if (textEditorTabs.length === 0) {
-        await vscode.window.showInformationMessage('No open editor tabs found');
-        return;
-      }
-
-      // Build QuickPick items with picked: true for checkbox state
-      const items: vscode.QuickPickItem[] = textEditorTabs.map(tab => {
-        const input = tab.input as vscode.TabInputText;
-        const uri = input.uri;
-        const fileName = vscode.workspace.asRelativePath(uri, false);
-        const fullPath = uri.fsPath;
-
-        // Extract directory for description (relative path without filename)
-        const dirMatch = fileName.match(/^(.+?)[/\\][^/\\]+$/);
-        const description = dirMatch ? dirMatch[1] + '/' : '';
-
-        return {
-          label: path.basename(fileName),
-          description: description,
-          detail: fullPath,
-          picked: true, // Pre-select all for checkbox state
-        };
-      });
-
-      // Use showQuickPick with canPickMany option
-      const selected = await vscode.window.showQuickPick(items, {
-        canPickMany: true,
-        placeholder: 'Select files to add to prompt',
-        matchOnDescription: true,
-        matchOnDetail: true,
-        title: 'Select Files to Add to OpenCode',
-      });
-
-      if (!selected || selected.length === 0) {
-        return; // User cancelled
-      }
-
-      const connected = await ensureConnected();
-      if (!connected || !openCodeClient) {
-        const msg = lastAutoSpawnError
-          ? `OpenCode auto-spawn failed: ${lastAutoSpawnError}`
-          : 'No OpenCode instance found. Run `opencode --port <port>` in your project directory.';
-        await vscode.window.showErrorMessage(msg);
-        return;
-      }
-
-      try {
-        const _port = openCodeClient.getPort();
-        const _workspaceDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || 'unknown';
-        outputChannel?.info(`[addMultipleFiles] Sending to port ${_port}, cwd: ${_workspaceDir}`);
-        // Build all file references with spaces between them
-        const refs = selected
-          .map(item => {
-            const relativePath = (item.description || '') + item.label;
-            return `@${relativePath}`;
-          })
-          .join(' ');
-
-        outputChannel?.debug(`[addMultipleFiles] Sending: "${refs}"`);
-        await openCodeClient.appendPrompt(refs);
-
-        outputChannel?.debug(`[addMultipleFiles] Sent ${selected.length} files`);
-      } catch (err) {
-        await vscode.window.showErrorMessage(
-          `Failed to send references: ${(err as Error).message}`
-        );
-      }
-    }
+    async () => handleAddMultipleFiles(connectionService!, outputChannel!)
   );
-
-  // Also register with opencode.* prefix for compatibility
-  const opencodeAddMultipleFilesCommand = vscode.commands.registerCommand(
-    'opencode.addMultipleFiles',
-    async () => {
-      // Get all tabs from all tab groups
-      const allTabs = vscode.window.tabGroups.all.flatMap(group => group.tabs);
-
-      // Filter to only text editor tabs (TabInputText)
-      const textEditorTabs = allTabs.filter(
-        (tab): tab is vscode.Tab => tab.input instanceof vscode.TabInputText
-      );
-
-      if (textEditorTabs.length === 0) {
-        await vscode.window.showInformationMessage('No open editor tabs found');
-        return;
-      }
-
-      // Build QuickPick items with picked: true for checkbox state
-      const items: vscode.QuickPickItem[] = textEditorTabs.map(tab => {
-        const input = tab.input as vscode.TabInputText;
-        const uri = input.uri;
-        const fileName = vscode.workspace.asRelativePath(uri, false);
-        const fullPath = uri.fsPath;
-
-        // Extract directory for description (relative path without filename)
-        const dirMatch = fileName.match(/^(.+?)[/\\][^/\\]+$/);
-        const description = dirMatch ? dirMatch[1] + '/' : '';
-
-        return {
-          label: path.basename(fileName),
-          description: description,
-          detail: fullPath,
-          picked: true, // Pre-select all for checkbox state
-        };
-      });
-
-      // Use showQuickPick with canPickMany option
-      const selected = await vscode.window.showQuickPick(items, {
-        canPickMany: true,
-        placeholder: 'Select files to add to prompt',
-        matchOnDescription: true,
-        matchOnDetail: true,
-        title: 'Select Files to Add to OpenCode',
-      });
-
-      if (!selected || selected.length === 0) {
-        return; // User cancelled
-      }
-
-      const connected = await ensureConnected();
-      if (!connected || !openCodeClient) {
-        const msg = lastAutoSpawnError
-          ? `OpenCode auto-spawn failed: ${lastAutoSpawnError}`
-          : 'No OpenCode instance found. Run `opencode --port <port>` in your project directory.';
-        await vscode.window.showErrorMessage(msg);
-        return;
-      }
-
-      try {
-        const _port = openCodeClient.getPort();
-        const _workspaceDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || 'unknown';
-        outputChannel?.info(`[addMultipleFiles] Sending to port ${_port}, cwd: ${_workspaceDir}`);
-        // Build all file references with spaces between them
-        const refs = selected
-          .map(item => {
-            const relativePath = (item.description || '') + item.label;
-            return `@${relativePath}`;
-          })
-          .join(' ');
-
-        outputChannel?.debug(`[addMultipleFiles] Sending: "${refs}"`);
-        await openCodeClient.appendPrompt(refs);
-
-        outputChannel?.debug(`[addMultipleFiles] Sent ${selected.length} files`);
-        showTransientNotification(`Sent ${selected.length} files to OpenCode`);
-      } catch (err) {
-        await vscode.window.showErrorMessage(
-          `Failed to send references: ${(err as Error).message}`
-        );
-      }
-    }
-  );
-
-  // Also register with opencode.* prefix for compatibility
 
   // Explain and Fix code action command
   const explainAndFixCommand = vscode.commands.registerCommand(
     'opencodeConnector.explainAndFix',
-    async (diagnostic: vscode.Diagnostic, uri: vscode.Uri) => {
-      const connected = await ensureConnected();
-      if (!connected || !openCodeClient) {
-        const msg = lastAutoSpawnError
-          ? `OpenCode auto-spawn failed: ${lastAutoSpawnError}`
-          : 'No OpenCode instance found. Run `opencode --port <port>` in your project directory.';
-        await vscode.window.showErrorMessage(msg);
-        return;
-      }
-
-      try {
-        // Format the prompt using the diagnostic
-        const prompt = formatPromptForDiagnostic(diagnostic, uri, uriInfo =>
-          vscode.workspace.asRelativePath(uriInfo.fsPath)
-        );
-        await openCodeClient.appendPrompt(prompt);
-        showTransientNotification(`Sent explanation request for diagnostic`);
-        // Auto-focus terminal if enabled
-        if (ConfigManager.getInstance().getAutoFocusTerminal()) {
-          try {
-            await InstanceManager.getInstance().focusTerminal();
-          } catch {
-            // Silently ignore focus errors - don't fail the main operation
-          }
-        }
-      } catch (err) {
-        await vscode.window.showErrorMessage(
-          `Failed to send explanation: ${(err as Error).message}`
-        );
-      }
-    }
+    async (diagnostic: vscode.Diagnostic, uri: vscode.Uri) =>
+      handleExplainAndFix(connectionService!, outputChannel!, diagnostic, uri)
   );
 
-  // Alias explainAndFix command with 'opencode.' prefix
+  // Alias commands with 'opencode.' prefix for compatibility
+  const opencodeCheckInstanceCommand = vscode.commands.registerCommand(
+    'opencode.checkInstance',
+    async () => handleCheckInstance(connectionService!, outputChannel!)
+  );
+
+  const opencodeShowWorkspaceCommand = vscode.commands.registerCommand(
+    'opencode.showWorkspace',
+    async () => handleShowWorkspace(connectionService!, outputChannel!)
+  );
+
+  const opencodeAddToPromptCommand = vscode.commands.registerCommand(
+    'opencode.addToPrompt',
+    async () => handleAddToPrompt(connectionService!, outputChannel!)
+  );
+
+  const opencodeAddMultipleFilesCommand = vscode.commands.registerCommand(
+    'opencode.addMultipleFiles',
+    async () => handleAddMultipleFiles(connectionService!, outputChannel!)
+  );
+
   const opencodeExplainAndFixCommand = vscode.commands.registerCommand(
     'opencode.explainAndFix',
-    async (diagnostic: vscode.Diagnostic, uri: vscode.Uri) => {
-      const connected = await ensureConnected();
-      if (!connected || !openCodeClient) {
-        const msg = lastAutoSpawnError
-          ? `OpenCode auto-spawn failed: ${lastAutoSpawnError}`
-          : 'No OpenCode instance found. Run `opencode --port <port>` in your project directory.';
-        await vscode.window.showErrorMessage(msg);
-        return;
-      }
-
-      try {
-        // Format the prompt using the diagnostic
-        const prompt = formatPromptForDiagnostic(diagnostic, uri, uriInfo =>
-          vscode.workspace.asRelativePath(uriInfo.fsPath)
-        );
-        await openCodeClient.appendPrompt(prompt);
-        showTransientNotification(`Sent explanation request for diagnostic`);
-        // Auto-focus terminal if enabled
-        if (ConfigManager.getInstance().getAutoFocusTerminal()) {
-          try {
-            await InstanceManager.getInstance().focusTerminal();
-          } catch {
-            // Silently ignore focus errors - don't fail the main operation
-          }
-        }
-      } catch (err) {
-        await vscode.window.showErrorMessage(
-          `Failed to send explanation: ${(err as Error).message}`
-        );
-      }
-    }
+    async (diagnostic: vscode.Diagnostic, uri: vscode.Uri) =>
+      handleExplainAndFix(connectionService!, outputChannel!, diagnostic, uri)
   );
 
   // Push all subscriptions for cleanup
   extensionContext?.subscriptions.push(
     statusCommand,
-    // Push all subscriptions for cleanup
-    statusCommand,
     workspaceCommand,
-    opencodeCheckInstanceCommand,
-    opencodeShowWorkspaceCommand,
-    opencodeAddFileCommand,
     addFileCommand,
     addMultipleFilesCommand,
-    opencodeAddMultipleFilesCommand,
-
     explainAndFixCommand,
+    opencodeCheckInstanceCommand,
+    opencodeShowWorkspaceCommand,
+    opencodeAddToPromptCommand,
+    opencodeAddMultipleFilesCommand,
     opencodeExplainAndFixCommand
   );
-}
-
-/**
- * Get the active file reference for OpenCode prompts.
- * Reads directly from VSCode API for reliability (no dependency on ContextManager event tracking).
- * Matches the official OpenCode VSCode SDK pattern.
- */
-function getActiveFileRef(): string | undefined {
-  const activeEditor = vscode.window.activeTextEditor;
-  if (!activeEditor) {
-    return undefined;
-  }
-
-  const document = activeEditor.document;
-  const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
-  if (!workspaceFolder) {
-    return undefined;
-  }
-
-  const relativePath = vscode.workspace.asRelativePath(document.uri);
-  let ref = `@${relativePath}`;
-
-  const selection = activeEditor.selection;
-  if (!selection.isEmpty) {
-    const startLine = selection.start.line + 1;
-    const endLine = selection.end.line + 1;
-    if (startLine === endLine) {
-      ref += `#L${startLine}`;
-    } else {
-      ref += `#L${startLine}-${endLine}`;
-    }
-  }
-
-  return ref;
 }
 
 /**
@@ -848,14 +222,6 @@ function registerWorkspaceHandlers(): void {
   const configChange = vscode.workspace.onDidChangeConfiguration(event => {
     if (event.affectsConfiguration('opencode')) {
       outputChannel?.info('OpenCode configuration changed');
-
-      // Update client if port changed
-      if (configManager && openCodeClient) {
-        const newPort = configManager.getPort();
-        if (newPort !== openCodeClient.getPort()) {
-          openCodeClient = new OpenCodeClient({ port: newPort });
-        }
-      }
     }
   });
 
@@ -874,13 +240,15 @@ export function deactivate(): void {
     contextManager = undefined;
   }
 
-  if (openCodeClient) {
-    openCodeClient.destroy();
-    openCodeClient = undefined;
+  if (connectionService) {
+    const client = connectionService.getClient();
+    if (client) {
+      client.destroy();
+    }
+    connectionService = undefined;
   }
 
   // Reset singletons
   InstanceManager.resetInstance();
   configManager = undefined;
-  instanceManager = undefined;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,6 @@ import {
   handleAddMultipleFiles,
   handleAddToPrompt,
   handleCheckInstance,
-  handleExplainAndFix,
   handleShowWorkspace,
 } from './commands';
 import { ConfigManager } from './config';
@@ -157,12 +156,6 @@ function registerCommands(): void {
     async () => handleAddMultipleFiles(connectionService!, outputChannel!)
   );
 
-  // Explain and Fix code action command
-  const explainAndFixCommand = vscode.commands.registerCommand(
-    'opencodeConnector.explainAndFix',
-    async (diagnostic: vscode.Diagnostic, uri: vscode.Uri) =>
-      handleExplainAndFix(connectionService!, outputChannel!, diagnostic, uri)
-  );
 
   // Push all subscriptions for cleanup
   extensionContext?.subscriptions.push(
@@ -170,7 +163,6 @@ function registerCommands(): void {
     workspaceCommand,
     addFileCommand,
     addMultipleFilesCommand,
-    explainAndFixCommand
   );
 }
 

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -204,6 +204,35 @@ export const WorkspaceUtils = {
   getWorkspaceHash(workspacePath: string): string {
     return crypto.createHash('md5').update(workspacePath).digest('hex').substring(0, 8);
   },
+
+  getActiveFileRef(): string | undefined {
+    const activeEditor = vscode.window.activeTextEditor;
+    if (!activeEditor) {
+      return undefined;
+    }
+
+    const document = activeEditor.document;
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
+    if (!workspaceFolder) {
+      return undefined;
+    }
+
+    const relativePath = vscode.workspace.asRelativePath(document.uri);
+    let ref = `@${relativePath}`;
+
+    const selection = activeEditor.selection;
+    if (!selection.isEmpty) {
+      const startLine = selection.start.line + 1;
+      const endLine = selection.end.line + 1;
+      if (startLine === endLine) {
+        ref += `#L${startLine}`;
+      } else {
+        ref += `#L${startLine}-${endLine}`;
+      }
+    }
+
+    return ref;
+  },
 };
 
 export default WorkspaceUtils;


### PR DESCRIPTION
## Summary

- Split monolithic `extension.ts` into modular components under `src/commands/` and `src/connection/`
- Removed duplicate command aliases (`opencode.*` vs `opencodeConnector.*`)
- Fixed command handlers receiving extra unused arguments
- Added `addMultipleFiles` command for multi-file selection