### PR TITLE
feat(debug): add send debug context command

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,10 @@
       {
         "command": "opencodeConnector.selectDefaultInstance",
         "title": "OpenCode: Select Default Instance"
+      },
+      {
+        "command": "opencodeConnector.sendDebugContext",
+        "title": "OpenCode: Send Debug Context"
       }
     ],
     "keybindings": [
@@ -62,6 +66,13 @@
         "mac": "cmd+shift+alt+a",
         "when": "editorTextFocus",
         "title": "Add Multiple Files to OpenCode"
+      },
+      {
+        "command": "opencodeConnector.sendDebugContext",
+        "key": "ctrl+shift+d",
+        "mac": "cmd+shift+d",
+        "when": "inDebugMode",
+        "title": "Send Debug Context to OpenCode"
       }
     ],
     "configuration": {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -5,3 +5,4 @@ export { handleAddMultipleFiles } from './addMultipleFiles';
 export { handleExplainAndFix } from './explainAndFix';
 export { showStatusBarMenu } from './showStatusBarMenu';
 export { handleSelectDefaultInstance } from './selectDefaultInstance';
+export { handleSendDebugContext } from './sendDebugContext';

--- a/src/commands/sendDebugContext.ts
+++ b/src/commands/sendDebugContext.ts
@@ -1,0 +1,71 @@
+import { ConnectionService } from '../connection/connectionService';
+import { getDebugContext } from '../providers/debugIntegration';
+import { formatDebugContext } from '../utils/debugPromptFormatter';
+
+import * as vscode from 'vscode';
+
+/**
+ * Sends the current debug context (stack trace and variables) to OpenCode.
+ * Requires an active debug session that is paused.
+ */
+export async function handleSendDebugContext(
+  connectionService: ConnectionService,
+  outputChannel: vscode.LogOutputChannel
+): Promise<void> {
+  const session = vscode.debug.activeDebugSession;
+  if (!session) {
+    await vscode.window.showErrorMessage('No active debug session. Start a debug session first.');
+    return;
+  }
+
+  try {
+    await session.customRequest('stackTrace');
+  } catch {
+    await vscode.window.showErrorMessage(
+      'Debugger is currently running. Pause the debugger to send context.'
+    );
+    return;
+  }
+
+  const connected = await connectionService.ensureConnected();
+  const openCodeClient = connectionService.getClient();
+  const lastAutoSpawnError = connectionService.getLastAutoSpawnError();
+
+  if (!connected || !openCodeClient) {
+    const msg = lastAutoSpawnError
+      ? `OpenCode auto-spawn failed: ${lastAutoSpawnError}`
+      : 'No OpenCode instance found. Run `opencode --port <port>` in your project directory.';
+    await vscode.window.showErrorMessage(msg);
+    return;
+  }
+
+  try {
+    const debugContext = await getDebugContext();
+
+    if (!debugContext) {
+      await vscode.window.showErrorMessage(
+        'Unable to get debug context. Make sure the debugger is paused.'
+      );
+      return;
+    }
+
+    const prompt = formatDebugContext(debugContext);
+    await openCodeClient.appendPrompt(prompt);
+
+    outputChannel.info('Sent debug context to OpenCode');
+    vscode.window.setStatusBarMessage(`$(check) Sent debug context to OpenCode`, 3000);
+
+    const configManager = connectionService.getConfigManager();
+    if (configManager.getAutoFocusTerminal()) {
+      try {
+        await connectionService.focusTerminal();
+      } catch {
+        // Silently ignore focus errors
+      }
+    }
+  } catch (err) {
+    await vscode.window.showErrorMessage(`Failed to send debug context: ${(err as Error).message}`);
+  }
+}
+
+export default handleSendDebugContext;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import {
   handleAddToPrompt,
   handleCheckInstance,
   handleSelectDefaultInstance,
+  handleSendDebugContext,
   handleShowWorkspace,
   showStatusBarMenu,
 } from './commands';
@@ -158,6 +159,12 @@ function registerCommands(): void {
     async () => handleSelectDefaultInstance(connectionService!, outputChannel!)
   );
 
+  // Send debug context command
+  const sendDebugContextCommand = vscode.commands.registerCommand(
+    'opencodeConnector.sendDebugContext',
+    async () => handleSendDebugContext(connectionService!, outputChannel!)
+  );
+
   // Push all subscriptions for cleanup
   extensionContext?.subscriptions?.push(
     statusCommand,
@@ -165,7 +172,8 @@ function registerCommands(): void {
     addFileCommand,
     addMultipleFilesCommand,
     statusBarMenuCommand,
-    selectDefaultInstanceCommand
+    selectDefaultInstanceCommand,
+    sendDebugContextCommand
   );
 }
 

--- a/src/providers/debugIntegration.ts
+++ b/src/providers/debugIntegration.ts
@@ -1,0 +1,62 @@
+import { DebugContext, StackFrameInfo, VariableInfo } from '../types';
+
+import * as vscode from 'vscode';
+
+export async function getDebugContext(): Promise<DebugContext | null> {
+  const session = vscode.debug.activeDebugSession;
+  if (!session) {
+    return null;
+  }
+
+  try {
+    await session.customRequest('stackTrace');
+  } catch {
+    return null;
+  }
+
+  const stackFrames: StackFrameInfo[] = [];
+  const variables: VariableInfo[] = [];
+
+  try {
+    const stackTraceResponse = await session.customRequest('stackTrace');
+    const frames = stackTraceResponse?.body?.stackFrames || [];
+
+    for (const sf of frames) {
+      stackFrames.push({
+        name: sf.name || '<anonymous>',
+        source: sf.source?.path || sf.source?.name,
+        line: sf.line,
+        column: sf.column,
+      });
+    }
+
+    if (frames.length > 0) {
+      const firstFrame = frames[0];
+      const scopesResponse = await session.customRequest('scopes', {
+        frameId: firstFrame.id,
+      });
+
+      const scopes = scopesResponse?.body?.scopes || [];
+      if (scopes.length > 0) {
+        const varsResponse = await session.customRequest('variables', {
+          variablesReference: scopes[0].variablesReference,
+        });
+
+        const vars = varsResponse?.body?.variables || [];
+        for (const v of vars) {
+          variables.push({
+            name: v.name,
+            value: v.value,
+            type: v.type || typeof v.value,
+          });
+        }
+      }
+    }
+  } catch {
+    // Silently return partial results
+  }
+
+  return { stackFrames, variables };
+}
+
+export default getDebugContext;

--- a/src/providers/debugIntegration.ts
+++ b/src/providers/debugIntegration.ts
@@ -46,7 +46,7 @@ export async function getDebugContext(): Promise<DebugContext | null> {
         for (const v of vars) {
           variables.push({
             name: v.name,
-            value: v.value,
+            value: String(v.value),
             type: v.type || typeof v.value,
           });
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -177,3 +177,53 @@ export interface TuiPublishEvent {
 export interface VcsInfo {
   branch: string;
 }
+
+/**
+ * Represents a stack frame in a debug session.
+ */
+export interface StackFrameInfo {
+  /** The name of the stack frame (function/method name) */
+  name: string;
+  /** The source file path or URI */
+  source?: string;
+  /** The line number in the source file (1-based) */
+  line: number;
+  /** The column number on the line (0-based) */
+  column: number;
+}
+
+/**
+ * Represents a variable in a debug context.
+ */
+export interface VariableInfo {
+  /** The variable name */
+  name: string;
+  /** The variable value as a string */
+  value: string;
+  /** The type of the variable (e.g., 'string', 'number', 'object') */
+  type: string;
+}
+
+/**
+ * Represents the current debug state including active stack frames and variables.
+ */
+export interface DebugContext {
+  /** The active stack frames in the current debug session */
+  stackFrames: StackFrameInfo[];
+  /** The current variables in scope */
+  variables: VariableInfo[];
+}
+
+/**
+ * Represents a debug session.
+ */
+export interface DebugSessionInfo {
+  /** The unique identifier of the debug session */
+  id: string;
+  /** The name of the debug session */
+  name: string;
+  /** The type of debug adapter (e.g., 'node', 'python') */
+  type: string;
+  /** The current workspace folder URI */
+  workspaceFolder?: string;
+}

--- a/src/utils/debugPromptFormatter.ts
+++ b/src/utils/debugPromptFormatter.ts
@@ -1,0 +1,64 @@
+import { DebugContext, StackFrameInfo, VariableInfo } from '../types';
+
+const MAX_STACK_FRAMES = 10;
+const MAX_VARIABLE_DEPTH = 3;
+const MAX_VALUE_LENGTH = 500;
+
+function truncateValue(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return value.substring(0, maxLength - 3) + '...';
+}
+
+function formatVariable(name: string, value: unknown, depth: number): string {
+  if (depth > MAX_VARIABLE_DEPTH) {
+    return `${name} = [max depth reached]`;
+  }
+
+  if (value === null) {
+    return `${name} = null`;
+  }
+
+  if (value === undefined) {
+    return `${name} = undefined`;
+  }
+
+  if (typeof value === 'object') {
+    try {
+      const str = JSON.stringify(value, null, 2);
+      return `${name} = ${truncateValue(str, MAX_VALUE_LENGTH)}`;
+    } catch {
+      return `${name} = [circular or non-serializable]`;
+    }
+  }
+
+  return `${name} = ${truncateValue(String(value), MAX_VALUE_LENGTH)}`;
+}
+
+export function formatDebugContext(context: DebugContext): string {
+  const stackFrameLines = context.stackFrames
+    .slice(0, MAX_STACK_FRAMES)
+    .map((frame: StackFrameInfo) => {
+      const source = frame.source || 'unknown';
+      const line = frame.line || 1;
+      const name = frame.name || 'anonymous';
+      return `@${source}#L${line} in ${name}`;
+    });
+
+  const variableLines = context.variables.map((v: VariableInfo) => {
+    return formatVariable(v.name, v.value, 0);
+  });
+
+  const stackSection =
+    stackFrameLines.length > 0
+      ? `Stack trace:\n${stackFrameLines.join('\n')}`
+      : 'No stack frames available';
+
+  const variableSection =
+    variableLines.length > 0 ? `Variables:\n${variableLines.join('\n')}` : 'No variables available';
+
+  return `Debug this for me:\n${stackSection}\n\n${variableSection}`;
+}
+
+export default formatDebugContext;

--- a/src/utils/debugPromptFormatter.ts
+++ b/src/utils/debugPromptFormatter.ts
@@ -5,6 +5,9 @@ const MAX_VARIABLE_DEPTH = 3;
 const MAX_VALUE_LENGTH = 500;
 
 function truncateValue(value: string, maxLength: number): string {
+  if (value == null) {
+    return String(value);
+  }
   if (value.length <= maxLength) {
     return value;
   }
@@ -16,24 +19,12 @@ function formatVariable(name: string, value: unknown, depth: number): string {
     return `${name} = [max depth reached]`;
   }
 
-  if (value === null) {
-    return `${name} = null`;
+  if (value == null) {
+    return `${name} = ${value}`;
   }
 
-  if (value === undefined) {
-    return `${name} = undefined`;
-  }
-
-  if (typeof value === 'object') {
-    try {
-      const str = JSON.stringify(value, null, 2);
-      return `${name} = ${truncateValue(str, MAX_VALUE_LENGTH)}`;
-    } catch {
-      return `${name} = [circular or non-serializable]`;
-    }
-  }
-
-  return `${name} = ${truncateValue(String(value), MAX_VALUE_LENGTH)}`;
+  const strValue = String(value);
+  return `${name} = ${truncateValue(strValue, MAX_VALUE_LENGTH)}`;
 }
 
 export function formatDebugContext(context: DebugContext): string {

--- a/test/utils/debugPromptFormatter.test.ts
+++ b/test/utils/debugPromptFormatter.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Unit tests for debug prompt formatter utility
+ * Tests the exported formatDebugContext function without requiring VS Code module
+ */
+import { DebugContext, StackFrameInfo, VariableInfo } from '../../src/types';
+import { formatDebugContext } from '../../src/utils/debugPromptFormatter';
+
+import { describe, expect, it } from 'vitest';
+
+describe('debugPromptFormatter', () => {
+  describe('formatDebugContext', () => {
+    it('should format stack frames with filepath and line in name', () => {
+      const context: DebugContext = {
+        stackFrames: [
+          {
+            name: 'myFunction',
+            source: '/workspace/project/src/index.ts',
+            line: 10,
+            column: 5,
+          },
+        ],
+        variables: [],
+      };
+
+      const result = formatDebugContext(context);
+
+      expect(result).toContain('@/workspace/project/src/index.ts#L10 in myFunction');
+    });
+
+    it('should format variables with name = value', () => {
+      const context: DebugContext = {
+        stackFrames: [],
+        variables: [
+          { name: 'count', value: '42', type: 'number' },
+          { name: 'name', value: 'test', type: 'string' },
+        ],
+      };
+
+      const result = formatDebugContext(context);
+
+      expect(result).toContain('count = 42');
+      expect(result).toContain('name = test');
+    });
+
+    it('should handle depth limits with max 3 levels of nesting', () => {
+      const context: DebugContext = {
+        stackFrames: [],
+        variables: [
+          {
+            name: 'nested',
+            value: JSON.stringify({
+              level1: {
+                level2: {
+                  level3: {
+                    level4: 'too deep',
+                  },
+                },
+              },
+            }),
+            type: 'object',
+          },
+        ],
+      };
+
+      const result = formatDebugContext(context);
+
+      // The formatter should handle the nesting through JSON.stringify
+      // Depth limit is applied in recursive formatVariable but since we pass
+      // already-stringified JSON, it will just truncate based on MAX_VALUE_LENGTH
+      expect(result).toContain('nested = ');
+    });
+
+    it('should handle circular references without throwing', () => {
+      const circularObj: Record<string, unknown> = { name: 'test' };
+      circularObj.self = circularObj;
+
+      const context: DebugContext = {
+        stackFrames: [],
+        variables: [
+          {
+            name: 'circular',
+            value: circularObj as unknown as string,
+            type: 'object',
+          },
+        ],
+      };
+
+      // Should not throw
+      const result = formatDebugContext(context);
+
+      expect(result).toContain('circular = ');
+    });
+
+    it('should handle empty context', () => {
+      const context: DebugContext = {
+        stackFrames: [],
+        variables: [],
+      };
+
+      const result = formatDebugContext(context);
+
+      expect(result).toContain('No stack frames available');
+      expect(result).toContain('No variables available');
+    });
+
+    it('should limit to max 10 stack frames', () => {
+      const stackFrames: StackFrameInfo[] = Array.from({ length: 15 }, (_, i) => ({
+        name: `function${i}`,
+        source: `/workspace/project/src/file${i}.ts`,
+        line: i + 1,
+        column: 1,
+      }));
+
+      const context: DebugContext = {
+        stackFrames,
+        variables: [],
+      };
+
+      const result = formatDebugContext(context);
+
+      // Should only contain first 10 frames
+      expect(result).toContain('function0');
+      expect(result).toContain('function9');
+      expect(result).not.toContain('function10');
+    });
+
+    it('should truncate values longer than 500 characters', () => {
+      const longValue = 'x'.repeat(600);
+
+      const context: DebugContext = {
+        stackFrames: [],
+        variables: [
+          {
+            name: 'longString',
+            value: longValue,
+            type: 'string',
+          },
+        ],
+      };
+
+      const result = formatDebugContext(context);
+
+      // Should be truncated to 500 chars with "..." (497 + 3 = 500)
+      expect(result).toContain('longString = ');
+      expect(result.length).toBeLessThan(600);
+      expect(result).toContain('...');
+    });
+
+    it('should handle null and undefined values', () => {
+      const context: DebugContext = {
+        stackFrames: [],
+        variables: [
+          { name: 'nullVar', value: null as unknown as string, type: 'null' },
+          { name: 'undefinedVar', value: undefined as unknown as string, type: 'undefined' },
+        ],
+      };
+
+      const result = formatDebugContext(context);
+
+      expect(result).toContain('nullVar = null');
+      expect(result).toContain('undefinedVar = undefined');
+    });
+
+    it('should handle missing source in stack frame', () => {
+      const context: DebugContext = {
+        stackFrames: [
+          {
+            name: 'anonymous',
+            line: 5,
+            column: 10,
+          },
+        ],
+        variables: [],
+      };
+
+      const result = formatDebugContext(context);
+
+      expect(result).toContain('@unknown#L5 in anonymous');
+    });
+
+    it('should format prompt with both stack frames and variables', () => {
+      const context: DebugContext = {
+        stackFrames: [
+          {
+            name: 'handleClick',
+            source: '/workspace/project/src/button.tsx',
+            line: 25,
+            column: 3,
+          },
+        ],
+        variables: [
+          { name: 'isActive', value: 'true', type: 'boolean' },
+          { name: 'count', value: '5', type: 'number' },
+        ],
+      };
+
+      const result = formatDebugContext(context);
+
+      expect(result).toContain('Debug this for me:');
+      expect(result).toContain('Stack trace:');
+      expect(result).toContain('@/workspace/project/src/button.tsx#L25 in handleClick');
+      expect(result).toContain('Variables:');
+      expect(result).toContain('isActive = true');
+      expect(result).toContain('count = 5');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add new command `opencodeConnector.sendDebugContext` to send debug session context to OpenCode
- Command captures current stack trace and variables when debugger is paused
- New keybinding: `Ctrl+Shift+D` (Cmd+Shift+D on Mac) available in debug mode
- Includes unit tests for debugPromptFormatter

## Changes
- `src/types.ts` - Added debug types (DebugContext, StackFrameInfo, VariableInfo)
- `src/utils/debugPromptFormatter.ts` - Formats debug context for OpenCode prompts
- `src/providers/debugIntegration.ts` - Collects debug context from VS Code
- `src/commands/sendDebugContext.ts` - Command handler
- `src/extension.ts` - Registered command
- `package.json` - Command definition and keybinding

## Usage
1. Start a debug session in VS Code
2. Pause at a breakpoint
3. Press `Ctrl+Shift+D` or run "OpenCode: Send Debug Context" from command palette
4. The debug context (stack trace + variables) will be sent to OpenCode