### PR TITLE
feat: add explorer context menu for sending paths to OpenCode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,7 @@ The project uses `@trivago/prettier-plugin-sort-imports` with this order:
 ```
 src/
 ├── api/           # HTTP clients, API types
-├── commands/      # VS Code command handlers
+├── commands/      # VS Code command handlers (addToPrompt, sendPath, sendRelativePath, etc.)
 ├── config.ts      # Configuration management
 ├── connection/    # Connection service
 ├── instance/     # Instance management
@@ -137,6 +137,29 @@ try {
 - Use `LogOutputChannel` for user-accessible logging (View → Output)
 - Return early with user messages for validation failures
 - Use `async/await` for all VS Code APIs
+
+#### Context Menu Commands
+
+When adding explorer context menu commands:
+- Define commands in `contributes.commands`
+- Define submenus in `contributes.submenus` (array of `{id, label}`)
+- Add submenu trigger to `contributes.menus["explorer/context"]`
+- Add submenu items to `contributes.menus["submenuId"]` (NOT `explorer/context/submenuId`)
+
+Example:
+```json
+"submenus": [
+  { "id": "myExtension.submenu", "label": "My Submenu" }
+],
+"menus": {
+  "explorer/context": [
+    { "submenu": "myExtension.submenu" }
+  ],
+  "myExtension.submenu": [
+    { "command": "myExtension.command", "label": "Do Something" }
+  ]
+}
+```
 
 ### Type Annotations
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ You shouldn't have to choose between a great editor (VS Code) and a great AI age
 | `OpenCode: Show Workspace` | Display workspace information detected by the extension |
 | `OpenCode: Show Menu` | Quick access menu from the status bar |
 
+### Explorer Context Menu
+
+Right-click files or folders in the Explorer to quickly send them to OpenCode:
+
+- **Add to Opencode → Send Path**: Send absolute file/folder paths (e.g., `@/home/user/project/src/file.ts`)
+- **Add to Opencode → Send Relative Path**: Send relative paths (e.g., `@src/file.ts`)
+
+Multiple files/folders can be selected. Directories include a trailing slash.
+
 ### Code Actions
 
 - **Explain and Fix (OpenCode)**: Click on any diagnostic (error, warning, info) and select this quick fix to send the error details to OpenCode for explanation and automatic fixing.

--- a/package.json
+++ b/package.json
@@ -131,18 +131,14 @@
     "menus": {
       "explorer/context": [
         {
-          "submenu": "opencodeConnector.addToOpencode",
-          "when": "resourceUri"
-        }
-      ],
-      "opencodeConnector.addToOpencode": [
-        {
           "command": "opencodeConnector.sendPath",
-          "label": "Send Path"
+          "label": "Send Path to OpenCode",
+          "group": "opencode"
         },
         {
           "command": "opencodeConnector.sendRelativePath",
-          "label": "Send Relative Path"
+          "label": "Send Relative Path to OpenCode",
+          "group": "opencode"
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,14 @@
       {
         "command": "opencodeConnector.sendDebugContext",
         "title": "OpenCode: Send Debug Context"
+      },
+      {
+        "command": "opencodeConnector.sendPath",
+        "title": "OpenCode: Send Path"
+      },
+      {
+        "command": "opencodeConnector.sendRelativePath",
+        "title": "OpenCode: Send Relative Path"
       }
     ],
     "keybindings": [
@@ -113,6 +121,30 @@
           "description": "Automatically focus OpenCode terminal after sending prompts"
         }
       }
+    },
+    "submenus": [
+      {
+        "id": "opencodeConnector.addToOpencode",
+        "label": "Add to Opencode"
+      }
+    ],
+    "menus": {
+      "explorer/context": [
+        {
+          "submenu": "opencodeConnector.addToOpencode",
+          "when": "resourceUri"
+        }
+      ],
+      "opencodeConnector.addToOpencode": [
+        {
+          "command": "opencodeConnector.sendPath",
+          "label": "Send Path"
+        },
+        {
+          "command": "opencodeConnector.sendRelativePath",
+          "label": "Send Relative Path"
+        }
+      ]
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -131,14 +131,17 @@
     "menus": {
       "explorer/context": [
         {
+          "submenu": "opencodeConnector.addToOpencode"
+        }
+      ],
+      "opencodeConnector.addToOpencode": [
+        {
           "command": "opencodeConnector.sendPath",
-          "label": "Send Path to OpenCode",
-          "group": "opencode"
+          "label": "Send Path"
         },
         {
           "command": "opencodeConnector.sendRelativePath",
-          "label": "Send Relative Path to OpenCode",
-          "group": "opencode"
+          "label": "Send Relative Path"
         }
       ]
     }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -6,3 +6,5 @@ export { handleExplainAndFix } from './explainAndFix';
 export { showStatusBarMenu } from './showStatusBarMenu';
 export { handleSelectDefaultInstance } from './selectDefaultInstance';
 export { handleSendDebugContext } from './sendDebugContext';
+export { handleSendPath } from './sendPath';
+export { handleSendRelativePath } from './sendRelativePath';

--- a/src/commands/sendPath.ts
+++ b/src/commands/sendPath.ts
@@ -35,10 +35,11 @@ function isDirectory(filePath: string): boolean {
 function formatPaths(resources: vscode.Uri[]): string {
   const paths = resources.map(uri => {
     const filePath = uri.fsPath;
+    let formatted = '@' + filePath;
     if (isDirectory(filePath)) {
-      return filePath + path.sep;
+      formatted += path.sep;
     }
-    return filePath;
+    return formatted;
   });
 
   return paths.join('\n');

--- a/src/commands/sendPath.ts
+++ b/src/commands/sendPath.ts
@@ -1,6 +1,6 @@
 import { ConnectionService } from '../connection/connectionService';
+import { formatPaths } from '../utils/pathUtils';
 
-import * as path from 'path';
 import * as vscode from 'vscode';
 
 /**
@@ -9,40 +9,6 @@ import * as vscode from 'vscode';
  */
 function showTransientNotification(message: string): void {
   vscode.window.setStatusBarMessage(`$(check) ${message}`, 3000);
-}
-
-/**
- * Check if a file path is a directory
- * @param filePath - The file path to check
- * @returns True if the path is a directory
- */
-function isDirectory(filePath: string): boolean {
-  // Check if path ends with a directory separator or has no extension
-  if (filePath.endsWith('/') || filePath.endsWith('\\')) {
-    return true;
-  }
-
-  const basename = path.basename(filePath);
-  // If basename has no extension, it's likely a directory
-  return !basename.includes('.');
-}
-
-/**
- * Format paths for sending to OpenCode
- * @param resources - Array of VS Code URIs
- * @returns Formatted path string with trailing slashes for directories
- */
-function formatPaths(resources: vscode.Uri[]): string {
-  const paths = resources.map(uri => {
-    const filePath = uri.fsPath;
-    let formatted = '@' + filePath;
-    if (isDirectory(filePath)) {
-      formatted += path.sep;
-    }
-    return formatted;
-  });
-
-  return paths.join('\n');
 }
 
 export async function handleSendPath(

--- a/src/commands/sendPath.ts
+++ b/src/commands/sendPath.ts
@@ -1,0 +1,98 @@
+import { ConnectionService } from '../connection/connectionService';
+
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+/**
+ * Show transient notification in status bar
+ * @param message - Message to display
+ */
+function showTransientNotification(message: string): void {
+  vscode.window.setStatusBarMessage(`$(check) ${message}`, 3000);
+}
+
+/**
+ * Check if a file path is a directory
+ * @param filePath - The file path to check
+ * @returns True if the path is a directory
+ */
+function isDirectory(filePath: string): boolean {
+  // Check if path ends with a directory separator or has no extension
+  if (filePath.endsWith('/') || filePath.endsWith('\\')) {
+    return true;
+  }
+
+  const basename = path.basename(filePath);
+  // If basename has no extension, it's likely a directory
+  return !basename.includes('.');
+}
+
+/**
+ * Format paths for sending to OpenCode
+ * @param resources - Array of VS Code URIs
+ * @returns Formatted path string with trailing slashes for directories
+ */
+function formatPaths(resources: vscode.Uri[]): string {
+  const paths = resources.map(uri => {
+    const filePath = uri.fsPath;
+    if (isDirectory(filePath)) {
+      return filePath + path.sep;
+    }
+    return filePath;
+  });
+
+  return paths.join('\n');
+}
+
+export async function handleSendPath(
+  connectionService: ConnectionService,
+  outputChannel: vscode.LogOutputChannel,
+  resources: vscode.Uri[]
+): Promise<void> {
+  if (!resources || resources.length === 0) {
+    await vscode.window.showWarningMessage('No files or directories selected');
+    return;
+  }
+
+  const connected = await connectionService.ensureConnected();
+  const openCodeClient = connectionService.getClient();
+  const lastAutoSpawnError = connectionService.getLastAutoSpawnError();
+
+  if (!connected || !openCodeClient) {
+    const msg = lastAutoSpawnError
+      ? `OpenCode auto-spawn failed: ${lastAutoSpawnError}`
+      : 'No OpenCode instance found. Run `opencode --port <port>` in your project directory.';
+    await vscode.window.showErrorMessage(msg);
+    return;
+  }
+
+  try {
+    const port = openCodeClient.getPort();
+    const workspaceDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || 'unknown';
+    const paths = formatPaths(resources);
+
+    outputChannel.info(`[sendPath] Sending to port ${port}, cwd: ${workspaceDir}`);
+    outputChannel.debug(`[sendPath] Content: "${paths}"`);
+
+    const result = await openCodeClient.appendPrompt(paths);
+    outputChannel.debug(`[sendPath] Result: ${result}`);
+
+    const count = resources.length;
+    showTransientNotification(`Sent ${count} path${count > 1 ? 's' : ''}`);
+
+    const configManager = connectionService.getConfigManager();
+    if (configManager.getAutoFocusTerminal()) {
+      outputChannel.debug(`[sendPath] Auto-focus enabled, attempting to focus terminal`);
+      try {
+        const focused = await connectionService.focusTerminal();
+        outputChannel.debug(`[sendPath] Terminal focus result: ${focused}`);
+      } catch (err) {
+        outputChannel.warn(`[sendPath] Terminal focus error: ${(err as Error).message}`);
+      }
+    } else {
+      outputChannel.debug(`[sendPath] Auto-focus disabled in config`);
+    }
+  } catch (err) {
+    await vscode.window.showErrorMessage(`Failed to send paths: ${(err as Error).message}`);
+  }
+}

--- a/src/commands/sendRelativePath.ts
+++ b/src/commands/sendRelativePath.ts
@@ -20,10 +20,11 @@ function formatRelativePaths(resources: vscode.Uri[]): string {
   const paths = resources.map(uri => {
     const relativePath = vscode.workspace.asRelativePath(uri, false);
 
+    let formatted = '@' + relativePath;
     if (isDirectory(uri.fsPath)) {
-      return relativePath + path.sep;
+      formatted += path.sep;
     }
-    return relativePath;
+    return formatted;
   });
 
   return paths.join('\n');

--- a/src/commands/sendRelativePath.ts
+++ b/src/commands/sendRelativePath.ts
@@ -1,32 +1,26 @@
 import { ConnectionService } from '../connection/connectionService';
+import { formatRelativePath, isDirectory } from '../utils/pathUtils';
 
-import * as path from 'path';
 import * as vscode from 'vscode';
 
+/**
+ * Show transient notification in status bar
+ * @param message - Message to display
+ */
 function showTransientNotification(message: string): void {
   vscode.window.setStatusBarMessage(`$(check) ${message}`, 3000);
 }
 
-function isDirectory(filePath: string): boolean {
-  if (filePath.endsWith('/') || filePath.endsWith('\\')) {
-    return true;
-  }
-
-  const basename = path.basename(filePath);
-  return !basename.includes('.');
-}
-
+/**
+ * Format relative paths for sending to OpenCode
+ * @param resources - Array of VS Code URIs
+ * @returns Formatted path string with @ prefix and trailing slashes for directories
+ */
 function formatRelativePaths(resources: vscode.Uri[]): string {
   const paths = resources.map(uri => {
     const relativePath = vscode.workspace.asRelativePath(uri, false);
-
-    let formatted = '@' + relativePath;
-    if (isDirectory(uri.fsPath)) {
-      formatted += path.sep;
-    }
-    return formatted;
+    return formatRelativePath(relativePath, isDirectory(uri.fsPath));
   });
-
   return paths.join('\n');
 }
 

--- a/src/commands/sendRelativePath.ts
+++ b/src/commands/sendRelativePath.ts
@@ -1,0 +1,83 @@
+import { ConnectionService } from '../connection/connectionService';
+
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+function showTransientNotification(message: string): void {
+  vscode.window.setStatusBarMessage(`$(check) ${message}`, 3000);
+}
+
+function isDirectory(filePath: string): boolean {
+  if (filePath.endsWith('/') || filePath.endsWith('\\')) {
+    return true;
+  }
+
+  const basename = path.basename(filePath);
+  return !basename.includes('.');
+}
+
+function formatRelativePaths(resources: vscode.Uri[]): string {
+  const paths = resources.map(uri => {
+    const relativePath = vscode.workspace.asRelativePath(uri, false);
+
+    if (isDirectory(uri.fsPath)) {
+      return relativePath + path.sep;
+    }
+    return relativePath;
+  });
+
+  return paths.join('\n');
+}
+
+export async function handleSendRelativePath(
+  connectionService: ConnectionService,
+  outputChannel: vscode.LogOutputChannel,
+  resources: vscode.Uri[]
+): Promise<void> {
+  if (!resources || resources.length === 0) {
+    await vscode.window.showWarningMessage('No files or directories selected');
+    return;
+  }
+
+  const connected = await connectionService.ensureConnected();
+  const openCodeClient = connectionService.getClient();
+  const lastAutoSpawnError = connectionService.getLastAutoSpawnError();
+
+  if (!connected || !openCodeClient) {
+    const msg = lastAutoSpawnError
+      ? `OpenCode auto-spawn failed: ${lastAutoSpawnError}`
+      : 'No OpenCode instance found. Run `opencode --port <port>` in your project directory.';
+    await vscode.window.showErrorMessage(msg);
+    return;
+  }
+
+  try {
+    const port = openCodeClient.getPort();
+    const workspaceDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || 'unknown';
+    const paths = formatRelativePaths(resources);
+
+    outputChannel.info(`[sendRelativePath] Sending to port ${port}, cwd: ${workspaceDir}`);
+    outputChannel.debug(`[sendRelativePath] Content: "${paths}"`);
+
+    const result = await openCodeClient.appendPrompt(paths);
+    outputChannel.debug(`[sendRelativePath] Result: ${result}`);
+
+    const count = resources.length;
+    showTransientNotification(`Sent ${count} relative path${count > 1 ? 's' : ''}`);
+
+    const configManager = connectionService.getConfigManager();
+    if (configManager.getAutoFocusTerminal()) {
+      outputChannel.debug(`[sendRelativePath] Auto-focus enabled, attempting to focus terminal`);
+      try {
+        const focused = await connectionService.focusTerminal();
+        outputChannel.debug(`[sendRelativePath] Terminal focus result: ${focused}`);
+      } catch (err) {
+        outputChannel.warn(`[sendRelativePath] Terminal focus error: ${(err as Error).message}`);
+      }
+    } else {
+      outputChannel.debug(`[sendRelativePath] Auto-focus disabled in config`);
+    }
+  } catch (err) {
+    await vscode.window.showErrorMessage(`Failed to send paths: ${(err as Error).message}`);
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,8 @@ import {
   handleCheckInstance,
   handleSelectDefaultInstance,
   handleSendDebugContext,
+  handleSendPath,
+  handleSendRelativePath,
   handleShowWorkspace,
   showStatusBarMenu,
 } from './commands';
@@ -165,6 +167,19 @@ function registerCommands(): void {
     async () => handleSendDebugContext(connectionService!, outputChannel!)
   );
 
+  // Send path command (from context menu)
+  const sendPathCommand = vscode.commands.registerCommand(
+    'opencodeConnector.sendPath',
+    async (resources: vscode.Uri[]) => handleSendPath(connectionService!, outputChannel!, resources)
+  );
+
+  // Send relative path command (from context menu)
+  const sendRelativePathCommand = vscode.commands.registerCommand(
+    'opencodeConnector.sendRelativePath',
+    async (resources: vscode.Uri[]) =>
+      handleSendRelativePath(connectionService!, outputChannel!, resources)
+  );
+
   // Push all subscriptions for cleanup
   extensionContext?.subscriptions?.push(
     statusCommand,
@@ -173,7 +188,9 @@ function registerCommands(): void {
     addMultipleFilesCommand,
     statusBarMenuCommand,
     selectDefaultInstanceCommand,
-    sendDebugContextCommand
+    sendDebugContextCommand,
+    sendPathCommand,
+    sendRelativePathCommand
   );
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -170,14 +170,25 @@ function registerCommands(): void {
   // Send path command (from context menu)
   const sendPathCommand = vscode.commands.registerCommand(
     'opencodeConnector.sendPath',
-    async (resources: vscode.Uri[]) => handleSendPath(connectionService!, outputChannel!, resources)
+    async (...resources: vscode.Uri[]) => {
+      const uris =
+        resources.length > 0 && Array.isArray(resources[resources.length - 1])
+          ? (resources[resources.length - 1] as unknown as vscode.Uri[])
+          : resources;
+      await handleSendPath(connectionService!, outputChannel!, uris);
+    }
   );
 
   // Send relative path command (from context menu)
   const sendRelativePathCommand = vscode.commands.registerCommand(
     'opencodeConnector.sendRelativePath',
-    async (resources: vscode.Uri[]) =>
-      handleSendRelativePath(connectionService!, outputChannel!, resources)
+    async (...resources: vscode.Uri[]) => {
+      const uris =
+        resources.length > 0 && Array.isArray(resources[resources.length - 1])
+          ? (resources[resources.length - 1] as unknown as vscode.Uri[])
+          : resources;
+      await handleSendRelativePath(connectionService!, outputChannel!, uris);
+    }
   );
 
   // Push all subscriptions for cleanup

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -1,0 +1,58 @@
+import * as path from 'path';
+
+/**
+ * Check if a file path is a directory based on heuristics:
+ * - Path ends with a directory separator
+ * - Basename has no extension (e.g., 'src', 'node_modules')
+ *
+ * Note: This is a heuristic and may misclassify extensionless files
+ * like 'Makefile', 'Dockerfile', or hidden files like '.gitignore'.
+ *
+ * @param filePath - The file path to check
+ * @returns True if the path appears to be a directory
+ */
+export function isDirectory(filePath: string): boolean {
+  if (filePath.endsWith('/') || filePath.endsWith('\\')) {
+    return true;
+  }
+
+  const basename = path.basename(filePath);
+  return !basename.includes('.');
+}
+
+/**
+ * Format an absolute path for sending to OpenCode
+ * @param fsPath - The absolute file system path
+ * @returns Formatted path string with @ prefix and trailing slash for directories
+ */
+export function formatAbsolutePath(fsPath: string): string {
+  let formatted = '@' + fsPath;
+  if (isDirectory(fsPath)) {
+    formatted += path.sep;
+  }
+  return formatted;
+}
+
+/**
+ * Format paths for sending to OpenCode
+ * @param resources - Array of VS Code URIs
+ * @returns Formatted path string with @ prefix and trailing slashes for directories
+ */
+export function formatPaths(resources: { fsPath: string }[]): string {
+  const paths = resources.map(uri => formatAbsolutePath(uri.fsPath));
+  return paths.join('\n');
+}
+
+/**
+ * Format a relative path for sending to OpenCode
+ * @param relativePath - The relative path
+ * @param isDir - Whether the path is a directory
+ * @returns Formatted path string with @ prefix and trailing slash for directories
+ */
+export function formatRelativePath(relativePath: string, isDir: boolean): string {
+  let formatted = '@' + relativePath;
+  if (isDir) {
+    formatted += path.sep;
+  }
+  return formatted;
+}

--- a/test/commands/sendPath.test.ts
+++ b/test/commands/sendPath.test.ts
@@ -1,0 +1,93 @@
+import * as path from 'path';
+import { describe, expect, it } from 'vitest';
+
+function isDirectory(filePath: string): boolean {
+  if (filePath.endsWith('/') || filePath.endsWith('\\')) {
+    return true;
+  }
+
+  const basename = path.basename(filePath);
+  return !basename.includes('.');
+}
+
+function formatPaths(resources: { fsPath: string }[]): string {
+  const paths = resources.map(uri => {
+    const filePath = uri.fsPath;
+    if (isDirectory(filePath)) {
+      return filePath + path.sep;
+    }
+    return filePath;
+  });
+
+  return paths.join('\n');
+}
+
+describe('sendPath utilities', () => {
+  describe('isDirectory', () => {
+    it('should return true for path ending with /', () => {
+      expect(isDirectory('/home/user/project/src/')).toBe(true);
+    });
+
+    it('should return true for path ending with \\', () => {
+      expect(isDirectory('C:\\Users\\project\\src\\')).toBe(true);
+    });
+
+    it('should return true for path with no extension', () => {
+      expect(isDirectory('/home/user/project/src')).toBe(true);
+    });
+
+    it('should return false for file with extension', () => {
+      expect(isDirectory('/home/user/project/src/index.ts')).toBe(false);
+    });
+
+    it('should return false for file with multiple dots', () => {
+      expect(isDirectory('/home/user/project/src/app.component.ts')).toBe(false);
+    });
+  });
+
+  describe('formatPaths', () => {
+    it('should not add trailing slash for files', () => {
+      const resources = [{ fsPath: '/home/user/project/src/index.ts' }];
+      const result = formatPaths(resources);
+      expect(result).toBe('/home/user/project/src/index.ts');
+    });
+
+    it('should add trailing slash for directories', () => {
+      const resources = [{ fsPath: '/home/user/project/src' }];
+      const result = formatPaths(resources);
+      expect(result).toBe('/home/user/project/src' + path.sep);
+    });
+
+    it('should separate multiple paths with newlines', () => {
+      const resources = [
+        { fsPath: '/home/user/project/src/index.ts' },
+        { fsPath: '/home/user/project/src/utils.ts' },
+      ];
+      const result = formatPaths(resources);
+      expect(result).toBe('/home/user/project/src/index.ts\n/home/user/project/src/utils.ts');
+    });
+
+    it('should handle mixed files and directories', () => {
+      const resources = [
+        { fsPath: '/home/user/project/src/index.ts' },
+        { fsPath: '/home/user/project/src/utils' },
+      ];
+      const result = formatPaths(resources);
+      expect(result).toBe(
+        '/home/user/project/src/index.ts\n/home/user/project/src/utils' + path.sep
+      );
+    });
+
+    it('should handle empty array', () => {
+      const resources: { fsPath: string }[] = [];
+      const result = formatPaths(resources);
+      expect(result).toBe('');
+    });
+
+    it('should handle single file', () => {
+      const resources = [{ fsPath: '/home/user/project/main.ts' }];
+      const result = formatPaths(resources);
+      expect(result).toBe('/home/user/project/main.ts');
+    });
+  });
+});

--- a/test/commands/sendPath.test.ts
+++ b/test/commands/sendPath.test.ts
@@ -1,26 +1,12 @@
+import {
+  formatAbsolutePath,
+  formatPaths,
+  formatRelativePath,
+  isDirectory,
+} from '../../src/utils/pathUtils';
+
 import * as path from 'path';
 import { describe, expect, it } from 'vitest';
-
-function isDirectory(filePath: string): boolean {
-  if (filePath.endsWith('/') || filePath.endsWith('\\')) {
-    return true;
-  }
-
-  const basename = path.basename(filePath);
-  return !basename.includes('.');
-}
-
-function formatPaths(resources: { fsPath: string }[]): string {
-  const paths = resources.map(uri => {
-    const filePath = uri.fsPath;
-    if (isDirectory(filePath)) {
-      return filePath + path.sep;
-    }
-    return filePath;
-  });
-
-  return paths.join('\n');
-}
 
 describe('sendPath utilities', () => {
   describe('isDirectory', () => {
@@ -45,17 +31,29 @@ describe('sendPath utilities', () => {
     });
   });
 
+  describe('formatAbsolutePath', () => {
+    it('should add @ prefix to file paths', () => {
+      const result = formatAbsolutePath('/home/user/project/src/index.ts');
+      expect(result).toBe('@/home/user/project/src/index.ts');
+    });
+
+    it('should add @ prefix and trailing slash for directories', () => {
+      const result = formatAbsolutePath('/home/user/project/src');
+      expect(result).toBe('@/home/user/project/src' + path.sep);
+    });
+  });
+
   describe('formatPaths', () => {
     it('should not add trailing slash for files', () => {
       const resources = [{ fsPath: '/home/user/project/src/index.ts' }];
       const result = formatPaths(resources);
-      expect(result).toBe('/home/user/project/src/index.ts');
+      expect(result).toBe('@/home/user/project/src/index.ts');
     });
 
-    it('should add trailing slash for directories', () => {
+    it('should add @ prefix and trailing slash for directories', () => {
       const resources = [{ fsPath: '/home/user/project/src' }];
       const result = formatPaths(resources);
-      expect(result).toBe('/home/user/project/src' + path.sep);
+      expect(result).toBe('@/home/user/project/src' + path.sep);
     });
 
     it('should separate multiple paths with newlines', () => {
@@ -64,7 +62,7 @@ describe('sendPath utilities', () => {
         { fsPath: '/home/user/project/src/utils.ts' },
       ];
       const result = formatPaths(resources);
-      expect(result).toBe('/home/user/project/src/index.ts\n/home/user/project/src/utils.ts');
+      expect(result).toBe('@/home/user/project/src/index.ts\n@/home/user/project/src/utils.ts');
     });
 
     it('should handle mixed files and directories', () => {
@@ -74,7 +72,7 @@ describe('sendPath utilities', () => {
       ];
       const result = formatPaths(resources);
       expect(result).toBe(
-        '/home/user/project/src/index.ts\n/home/user/project/src/utils' + path.sep
+        '@/home/user/project/src/index.ts\n@/home/user/project/src/utils' + path.sep
       );
     });
 
@@ -87,7 +85,24 @@ describe('sendPath utilities', () => {
     it('should handle single file', () => {
       const resources = [{ fsPath: '/home/user/project/main.ts' }];
       const result = formatPaths(resources);
-      expect(result).toBe('/home/user/project/main.ts');
+      expect(result).toBe('@/home/user/project/main.ts');
+    });
+  });
+
+  describe('formatRelativePath', () => {
+    it('should add @ prefix to relative file paths', () => {
+      const result = formatRelativePath('src/index.ts', false);
+      expect(result).toBe('@src/index.ts');
+    });
+
+    it('should add @ prefix and trailing slash for relative directories', () => {
+      const result = formatRelativePath('src', true);
+      expect(result).toBe('@src' + path.sep);
+    });
+
+    it('should handle nested paths', () => {
+      const result = formatRelativePath('src/utils/helpers.ts', false);
+      expect(result).toBe('@src/utils/helpers.ts');
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add Explorer context menu with "Add to Opencode" submenu
- "Send Path" sends absolute file/folder paths with `@` prefix
- "Send Relative Path" sends relative paths (per-workspace) with `@` prefix
- Supports multiple selected files/folders
- Each path on separate line
- Directories include trailing slash

## Changes

- Add `sendPath` and `sendRelativePath` commands
- Add context menu submenu configuration in package.json
- Update README and AGENTS.md documentation
- Fix VS Code submenu contribution syntax

## Testing

- Manual testing with single and multiple file selection
- All existing tests pass