### PR TITLE
fix: improve OpenCode instance discovery for Remote SSH environments

### DIFF
--- a/src/connection/connectionService.ts
+++ b/src/connection/connectionService.ts
@@ -102,9 +102,23 @@ export class ConnectionService {
           this.outputChannel?.debug(
             `[discoverAndConnect] Port ${port} server dir: "${pathInfo.directory}" vs workspace: "${workspaceDir}"`
           );
+          this.outputChannel?.debug(`[discoverAndConnect] process.cwd(): "${process.cwd()}"`);
 
           const matches = pathsMatch(pathInfo.directory, workspaceDir);
           this.outputChannel?.debug(`[discoverAndConnect] Paths match: ${matches}`);
+
+          const normalize = (p: string): string => {
+            let resolved = path.resolve(p);
+            resolved = path.normalize(resolved);
+            resolved = resolved.replace(/[\\/]+$/, '');
+            return resolved;
+          };
+          this.outputChannel?.debug(
+            `[discoverAndConnect] Normalized server: "${normalize(pathInfo.directory)}"`
+          );
+          this.outputChannel?.debug(
+            `[discoverAndConnect] Normalized workspace: "${normalize(workspaceDir)}"`
+          );
 
           // Normalize paths for comparison (platform-aware)
           if (matches) {

--- a/src/connection/connectionService.ts
+++ b/src/connection/connectionService.ts
@@ -107,17 +107,11 @@ export class ConnectionService {
           const matches = pathsMatch(pathInfo.directory, workspaceDir);
           this.outputChannel?.debug(`[discoverAndConnect] Paths match: ${matches}`);
 
-          const normalize = (p: string): string => {
-            let resolved = path.resolve(p);
-            resolved = path.normalize(resolved);
-            resolved = resolved.replace(/[\\/]+$/, '');
-            return resolved;
-          };
           this.outputChannel?.debug(
-            `[discoverAndConnect] Normalized server: "${normalize(pathInfo.directory)}"`
+            `[discoverAndConnect] Normalized server: "${normalizePath(pathInfo.directory)}"`
           );
           this.outputChannel?.debug(
-            `[discoverAndConnect] Normalized workspace: "${normalize(workspaceDir)}"`
+            `[discoverAndConnect] Normalized workspace: "${normalizePath(workspaceDir)}"`
           );
 
           // Normalize paths for comparison (platform-aware)
@@ -442,6 +436,21 @@ export function isRemoteSession(): boolean {
 }
 
 /**
+ * Normalize a filesystem path for comparison.
+ * @param p - Path to normalize
+ * @returns Normalized path string
+ */
+export function normalizePath(p: string): string {
+  // Resolve relative paths to absolute (handles "." and "./")
+  let resolved = path.resolve(p);
+  // Normalize separators to platform default
+  resolved = path.normalize(resolved);
+  // Remove trailing slashes
+  resolved = resolved.replace(/[\\/]+$/, '');
+  return resolved;
+}
+
+/**
  * Normalize and compare filesystem paths across platforms.
  * Handles: path separators, trailing slashes, remote path formats.
  * @param serverPath - Path returned by OpenCode server
@@ -449,19 +458,8 @@ export function isRemoteSession(): boolean {
  * @returns true if paths refer to the same directory
  */
 export function pathsMatch(serverPath: string, localPath: string): boolean {
-  // Normalize: resolve to absolute, remove trailing separators, lowercase if case-insensitive
-  const normalize = (p: string): string => {
-    // Resolve relative paths to absolute (handles "." and "./")
-    let resolved = path.resolve(p);
-    // Normalize separators to platform default
-    resolved = path.normalize(resolved);
-    // Remove trailing slashes
-    resolved = resolved.replace(/[\\/]+$/, '');
-    return resolved;
-  };
-
-  const normalizedServer = normalize(serverPath);
-  const normalizedLocal = normalize(localPath);
+  const normalizedServer = normalizePath(serverPath);
+  const normalizedLocal = normalizePath(localPath);
 
   // Handle empty input paths - return false
   if (!serverPath || !localPath) {

--- a/src/instance/instanceManager.ts
+++ b/src/instance/instanceManager.ts
@@ -365,95 +365,47 @@ export class InstanceManager {
 
   /**
    * Scan for OpenCode processes on Unix (Linux/macOS)
+   * Uses ss (socket statistics) for reliable detection in SSH environments
    */
   private scanProcessesUnix(): Promise<DiscoveredProcess[]> {
     return new Promise(resolve => {
-      // Find PIDs of opencode processes
-      // Match opencode at word boundary or after path separator
-      // Matches: "opencode", "opencode --port 4096", "/usr/bin/opencode", "./opencode"
-      // Does NOT match: "opencode-extra", "opencodehelper", "my-opencode-tool"
-      const pgrep = child_process.spawn('pgrep', ['-f', '(^|/)opencode($|\\s)']);
+      const ss = child_process.spawn('ss', ['-tlnp']);
+      let ssOut = '';
 
-      this.logger?.info('[scanProcessesUnix] Running pgrep for opencode processes');
-
-      let stdout = '';
-
-      pgrep.stdout.on('data', data => {
-        stdout += data.toString();
+      ss.stdout.on('data', data => {
+        ssOut += data.toString();
       });
-      pgrep.on('error', err => {
-        this.logger?.warn(`[scanProcessesUnix] pgrep error: ${err.message}`);
+      ss.on('error', err => {
+        this.logger?.warn(`[scanProcessesUnix] ss error: ${err.message}`);
         resolve([]);
       });
-      pgrep.on('close', code => {
-        if (code !== 0 && code !== 1) {
-          // code 1 means no processes found (which is fine)
-          this.logger?.warn(`[scanProcessesUnix] pgrep exited with code ${code}`);
-        }
-
-        const pids = stdout
-          .trim()
-          .split('\n')
-          .map(s => parseInt(s.trim(), 10))
-          .filter(n => !isNaN(n));
-
-        this.logger?.info(`[scanProcessesUnix] Found PIDs: ${pids.join(', ') || 'none'}`);
-
-        if (pids.length === 0) {
-          resolve([]);
-          return;
-        }
-
-        // For each PID, find its listening port via lsof
+      ss.on('close', () => {
         const results: DiscoveredProcess[] = [];
-        let pending = pids.length;
 
-        for (const pid of pids) {
-          const lsof = child_process.spawn('lsof', [
-            '-w',
-            '-iTCP',
-            '-sTCP:LISTEN',
-            '-P',
-            '-n',
-            '-a',
-            '-p',
-            String(pid),
-          ]);
-          let lsofOut = '';
+        for (const line of ssOut.split('\n')) {
+          if (!line.includes('LISTEN')) continue;
 
-          lsof.stdout.on('data', data => {
-            lsofOut += data.toString();
-          });
-          lsof.on('error', () => {
-            pending--;
-            if (pending === 0) resolve(results);
-          });
-          lsof.on('close', () => {
-            for (const line of lsofOut.split('\n')) {
-              if (line.startsWith('COMMAND')) continue; // skip header
-              const parts = line.trim().split(/\s+/);
-              // lsof format: COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME
-              // NAME is like "127.0.0.1:4096" or "*:4096"
-              const namePart = parts[8];
-              if (namePart) {
-                const portMatch = namePart.match(/:(\d+)$/);
-                if (portMatch) {
-                  const port = parseInt(portMatch[1], 10);
-                  if (!isNaN(port)) {
-                    results.push({ pid, port });
-                  }
-                }
-              }
-            }
-            pending--;
-            if (pending === 0) {
-              this.logger?.info(
-                `[scanProcessesUnix] Found processes with ports: ${JSON.stringify(results)}`
-              );
-              resolve(results);
-            }
-          });
+          const processMatch = line.match(/users:\(\("(?:\.?opencode)"[^)]+\)/);
+          if (!processMatch) continue;
+
+          const pidMatch = line.match(/pid=(\d+)/);
+          if (!pidMatch) continue;
+
+          const pid = parseInt(pidMatch[1], 10);
+
+          const portMatch = line.match(/(\d+\.\d+\.\d+\.\d+|\[::\]|\*):(\d+)/);
+          if (!portMatch) continue;
+
+          const port = parseInt(portMatch[2], 10);
+          if (isNaN(port)) continue;
+
+          results.push({ pid, port });
         }
+
+        this.logger?.info(
+          `[scanProcessesUnix] Found processes with ports: ${JSON.stringify(results)}`
+        );
+        resolve(results);
       });
     });
   }


### PR DESCRIPTION
## Summary
- Replace `pgrep`+`lsof` with `ss` (socket statistics) for reliable port detection in Remote SSH environments
- Fix PID mismatch issue where pgrep matched wrapper processes instead of actual opencode server processes
- Add debug logging for path comparison in connectionService

## Problem
In Remote SSH environments, the extension couldn't detect running OpenCode instances because:
1. `pgrep` was matching parent/wrapper processes with different PIDs than the actual opencode servers
2. `lsof` returned empty output due to permissions issues in SSH environments

## Solution
- Use `ss -tlnp` directly to find listening ports with process info
- Parse the output to match `.opencode` processes by name
- This approach is more reliable and doesn't require special permissions

## Testing
- Verified on Remote SSH connection to Ubuntu
- Successfully discovers 4 OpenCode instances on ports 4096, 4098, 4099, 4100
- Auto-connects to the correct instance