### PR TITLE
feat: workspace-aware routing, editor integration and Windows path fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/**
 temp/**
 nul
 research/**
+.atl/**

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -12,3 +12,4 @@ esbuild.js
 package-lock.json
 **/*.ts
 **/*.map
+.atl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2026-04-23
+
+### Added
+- Editor title bar button to open OpenCode as an editor tab for the current workspace
+- Explorer context menu entry **Open in OpenCode** (group `navigation`) to launch or re-attach an instance for any folder
+- Editor right-click command **Add Selection to OpenCode** — sends the selected range as `@file#L10-L20` (visible only when text is selected)
+- Workspace-aware routing: all send commands now resolve and connect to the correct OpenCode instance for the workspace of the active file; multi-root workspaces are fully supported
+- `findPortForWorkspace()` on `ConnectionService` — lightweight port lookup without mutating connection state
+- `openOpencodeForWorkspace()` shared helper used by both the title bar button and the Explorer context menu
+- `SpawnTerminalOptions` on `InstanceManager.spawnInTerminal()` — `asEditor: true` opens the terminal as an editor tab (`TerminalLocation.Editor`)
+- `.vscode/launch.json` and `.vscode/tasks.json` for F5 extension development
+
+### Fixed
+- Windows path separator normalization: `formatRelativePath` and `getActiveFileRef` now use `path.sep` instead of always producing forward slashes
+
 ## [1.2.0] - 2026-02-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -28,19 +28,41 @@ You shouldn't have to choose between a great editor (VS Code) and a great AI age
 | Command | Description | Keyboard Shortcut |
 |---------|-------------|-------------------|
 | `OpenCode: Add to Prompt` | Send the current file reference (e.g., `@src/main.ts#L10-L20`) to the TUI | `Ctrl+Shift+A` / `Cmd+Shift+A` |
+| `OpenCode: Add Selection to Prompt` | Send the selected code range (e.g., `@src/main.ts#L10-L20`) to the TUI | Right-click in editor |
 | `OpenCode: Select Files to Add` | Open a file picker to select multiple files to add to the prompt | `Ctrl+Shift+Alt+A` / `Cmd+Shift+Alt+A` |
-| `OpenCode: Check Instance` | Check if an OpenCode instance is running and connected |
-| `OpenCode: Show Workspace` | Display workspace information detected by the extension |
-| `OpenCode: Show Menu` | Quick access menu from the status bar |
+| `OpenCode: Open in OpenCode` | Open an OpenCode instance for the current workspace as an editor tab | Editor title bar / Explorer right-click |
+| `OpenCode: Check Instance` | Check if an OpenCode instance is running and connected | — |
+| `OpenCode: Show Workspace` | Display workspace information detected by the extension | — |
+| `OpenCode: Show Menu` | Quick access menu from the status bar | — |
+
+### Editor Title Button
+
+A terminal button (⬛) appears in the editor title bar for quick access. Clicking it:
+
+1. Finds a running OpenCode instance for the **current workspace** folder.
+2. Opens it as an **editor tab** (like Claude Code) — keeps your terminal panel free.
+3. If no instance is running, spawns one automatically.
+
+### Editor Context Menu
+
+Right-click inside any editor to send your selection directly to OpenCode:
+
+- **Add Selection to OpenCode**: Sends the selected code range as `@file#L10-L20` to the active OpenCode instance.
+  - Appears only when text is selected (`editorHasSelection`).
 
 ### Explorer Context Menu
 
-Right-click files or folders in the Explorer to quickly send them to OpenCode:
+Right-click files or folders in the Explorer for two sets of actions:
 
+- **Open in OpenCode**: Launch (or re-attach to) an OpenCode instance for that folder's workspace — opens as an editor tab.
 - **Add to Opencode → Send Path**: Send absolute file/folder paths (e.g., `@/home/user/project/src/file.ts`)
 - **Add to Opencode → Send Relative Path**: Send relative paths (e.g., `@src/file.ts`)
 
 Multiple files/folders can be selected. Directories include a trailing slash.
+
+### Workspace-Aware Routing
+
+All send commands automatically route to the **correct OpenCode instance** for the workspace of your active file. In multi-root workspaces each root folder gets its own instance — no manual switching required.
 
 ### Code Actions
 
@@ -53,16 +75,18 @@ Multiple files/folders can be selected. Directories include a trailing slash.
 
 ### Integrated Terminal
 
-- Runs the OpenCode TUI directly within VS Code's terminal panel
+- Runs the OpenCode TUI directly within VS Code's terminal or as an editor tab
 - Auto-focuses the terminal after sending prompts (configurable)
 
 ## Usage
 
 1.  Open your project in VS Code.
-2.  The extension will find or spawn an OpenCode TUI session.
-3.  Use **`OpenCode: Add to Prompt`** (or `Ctrl+Shift+A`) to reference your current code in the TUI.
-4.  Use **`OpenCode: Select Files to Add`** (or `Ctrl+Shift+Alt+A`) to pick multiple files to add to the prompt.
-5.  Use **`Explain and Fix (OpenCode)`** to quickly fix errors - hover over any error or click the lightbulb.
+2.  The extension will find or spawn an OpenCode TUI session for your workspace.
+3.  Click the **⬛ button** in the editor title bar (or right-click a folder → **Open in OpenCode**) to open the TUI as an editor tab.
+4.  Use **`OpenCode: Add to Prompt`** (`Ctrl+Shift+A`) to reference your current file in the TUI.
+5.  **Select code** in the editor, right-click → **Add Selection to OpenCode** to send the exact line range.
+6.  Use **`OpenCode: Select Files to Add`** (`Ctrl+Shift+Alt+A`) to pick multiple files at once.
+7.  Use **`Explain and Fix (OpenCode)`** to quickly fix errors — hover over any error or click the lightbulb.
 
 ## Configuration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-connector",
-  "version": "0.0.2",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-connector",
-      "version": "0.0.2",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,20 @@
       {
         "command": "opencodeConnector.sendRelativePath",
         "title": "OpenCode: Send Relative Path"
+      },
+      {
+        "command": "opencodeConnector.addSelectionToPrompt",
+        "title": "OpenCode: Add to Opencode"
+      },
+      {
+        "command": "opencodeConnector.openNewInstance",
+        "title": "OpenCode: Open New Instance",
+        "icon": "$(terminal-tmux)"
+      },
+      {
+        "command": "opencodeConnector.openInOpencode",
+        "title": "Open in OpenCode",
+        "icon": "$(terminal-tmux)"
       }
     ],
     "keybindings": [
@@ -131,6 +145,10 @@
     "menus": {
       "explorer/context": [
         {
+          "command": "opencodeConnector.openInOpencode",
+          "group": "navigation@10"
+        },
+        {
           "submenu": "opencodeConnector.addToOpencode"
         }
       ],
@@ -142,6 +160,20 @@
         {
           "command": "opencodeConnector.sendRelativePath",
           "label": "Send Relative Path"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "opencodeConnector.addSelectionToPrompt",
+          "when": "editorHasSelection",
+          "group": "opencodeConnector@1"
+        }
+      ],
+      "editor/title": [
+        {
+          "command": "opencodeConnector.openNewInstance",
+          "when": "editorIsOpen",
+          "group": "navigation"
         }
       ]
     }

--- a/src/commands/addMultipleFiles.ts
+++ b/src/commands/addMultipleFiles.ts
@@ -51,7 +51,17 @@ export async function handleAddMultipleFiles(
     return;
   }
 
-  const connected = await connectionService.ensureConnected();
+  // Use the active editor's workspace (or the first workspace folder) to route
+  // to the correct OpenCode instance in multi-root / multi-project setups.
+  const activeEditor = vscode.window.activeTextEditor;
+  const workspacePath = activeEditor
+    ? vscode.workspace.getWorkspaceFolder(activeEditor.document.uri)?.uri.fsPath
+    : vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+
+  const connected = workspacePath
+    ? await connectionService.ensureConnectedForWorkspace(workspacePath)
+    : await connectionService.ensureConnected();
+
   const openCodeClient = connectionService.getClient();
   const lastAutoSpawnError = connectionService.getLastAutoSpawnError();
 
@@ -65,7 +75,7 @@ export async function handleAddMultipleFiles(
 
   try {
     const port = openCodeClient.getPort();
-    const workspaceDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || 'unknown';
+    const workspaceDir = workspacePath ?? 'unknown';
     outputChannel.info(`[addMultipleFiles] Sending to port ${port}, cwd: ${workspaceDir}`);
 
     const refs = selected

--- a/src/commands/addSelectionToPrompt.ts
+++ b/src/commands/addSelectionToPrompt.ts
@@ -7,18 +7,17 @@ function showTransientNotification(message: string): void {
   vscode.window.setStatusBarMessage(`$(check) ${message}`, 3000);
 }
 
-export async function handleAddToPrompt(
+export async function handleAddSelectionToPrompt(
   connectionService: ConnectionService,
   outputChannel: vscode.LogOutputChannel
 ): Promise<void> {
   const ref = WorkspaceUtils.getActiveFileRef();
   if (!ref) {
-    await vscode.window.showWarningMessage('No active file to reference');
+    await vscode.window.showWarningMessage('No active file or selection to reference');
     return;
   }
 
-  // Resolve the workspace folder of the active file so we connect to the
-  // correct OpenCode instance in multi-root / multi-project setups.
+  // Connect to the OpenCode instance that serves the active file's workspace.
   const activeEditor = vscode.window.activeTextEditor;
   const workspacePath = activeEditor
     ? vscode.workspace.getWorkspaceFolder(activeEditor.document.uri)?.uri.fsPath
@@ -42,25 +41,25 @@ export async function handleAddToPrompt(
   try {
     const port = openCodeClient.getPort();
     const workspaceDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || 'unknown';
-    outputChannel.info(`[addToPrompt] Sending to port ${port}, cwd: ${workspaceDir}`);
-    outputChannel.debug(`[addToPrompt] Content: "${ref}"`);
+    outputChannel.info(`[addSelectionToPrompt] Sending to port ${port}, cwd: ${workspaceDir}`);
+    outputChannel.debug(`[addSelectionToPrompt] Content: "${ref}"`);
     const result = await openCodeClient.appendPrompt(ref);
-    outputChannel.debug(`[addToPrompt] Result: ${result}`);
+    outputChannel.debug(`[addSelectionToPrompt] Result: ${result}`);
     showTransientNotification(`Sent: ${ref}`);
 
     const configManager = connectionService.getConfigManager();
     if (configManager.getAutoFocusTerminal()) {
-      outputChannel.debug(`[addToPrompt] Auto-focus enabled, attempting to focus terminal`);
+      outputChannel.debug(`[addSelectionToPrompt] Auto-focus enabled, attempting to focus terminal`);
       try {
         const focused = await connectionService.focusTerminal();
-        outputChannel.debug(`[addToPrompt] Terminal focus result: ${focused}`);
+        outputChannel.debug(`[addSelectionToPrompt] Terminal focus result: ${focused}`);
       } catch (err) {
-        outputChannel.warn(`[addToPrompt] Terminal focus error: ${(err as Error).message}`);
+        outputChannel.warn(`[addSelectionToPrompt] Terminal focus error: ${(err as Error).message}`);
       }
     } else {
-      outputChannel.debug(`[addToPrompt] Auto-focus disabled in config`);
+      outputChannel.debug(`[addSelectionToPrompt] Auto-focus disabled in config`);
     }
   } catch (err) {
-    await vscode.window.showErrorMessage(`Failed to send reference: ${(err as Error).message}`);
+    await vscode.window.showErrorMessage(`Failed to send selection: ${(err as Error).message}`);
   }
 }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -8,3 +8,6 @@ export { handleSelectDefaultInstance } from './selectDefaultInstance';
 export { handleSendDebugContext } from './sendDebugContext';
 export { handleSendPath } from './sendPath';
 export { handleSendRelativePath } from './sendRelativePath';
+export { handleAddSelectionToPrompt } from './addSelectionToPrompt';
+export { handleOpenNewInstance } from './openNewInstance';
+export { handleOpenInOpencode } from './openInOpencode';

--- a/src/commands/openInOpencode.ts
+++ b/src/commands/openInOpencode.ts
@@ -1,0 +1,44 @@
+import { ConnectionService } from '../connection/connectionService';
+import { InstanceManager } from '../instance/instanceManager';
+import { openOpencodeForWorkspace } from './openNewInstance';
+
+import * as vscode from 'vscode';
+
+/**
+ * Handle the "Open in OpenCode" Explorer context menu command.
+ *
+ * Receives the right-clicked file or folder URI, resolves its workspace folder,
+ * and delegates to openOpencodeForWorkspace which either focuses an existing
+ * instance or spawns a new one — always as an editor tab.
+ *
+ * @param connectionService - Active connection service
+ * @param instanceManager   - Instance manager for process scanning and spawning
+ * @param outputChannel     - Log output channel
+ * @param uri               - URI of the right-clicked file or folder
+ */
+export async function handleOpenInOpencode(
+  connectionService: ConnectionService,
+  instanceManager: InstanceManager,
+  outputChannel: vscode.LogOutputChannel,
+  uri: vscode.Uri
+): Promise<void> {
+  const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
+
+  if (!workspaceFolder) {
+    await vscode.window.showWarningMessage(
+      'OpenCode: The selected item is not inside a workspace folder.'
+    );
+    return;
+  }
+
+  outputChannel.info(
+    `[openInOpencode] Triggered for "${uri.fsPath}" → workspace: "${workspaceFolder.uri.fsPath}"`
+  );
+
+  await openOpencodeForWorkspace(
+    workspaceFolder.uri.fsPath,
+    connectionService,
+    instanceManager,
+    outputChannel
+  );
+}

--- a/src/commands/openNewInstance.ts
+++ b/src/commands/openNewInstance.ts
@@ -1,0 +1,125 @@
+import { ConnectionService } from '../connection/connectionService';
+import { InstanceManager } from '../instance/instanceManager';
+
+import * as vscode from 'vscode';
+
+/**
+ * Resolve the workspace folder for the currently active editor file.
+ * Falls back to the first workspace folder if no editor is active.
+ */
+function resolveActiveWorkspace(): vscode.WorkspaceFolder | undefined {
+  const activeEditor = vscode.window.activeTextEditor;
+
+  if (activeEditor) {
+    const folder = vscode.workspace.getWorkspaceFolder(activeEditor.document.uri);
+    if (folder) {
+      return folder;
+    }
+  }
+
+  return vscode.workspace.workspaceFolders?.[0];
+}
+
+/**
+ * Core logic: given a resolved workspace path, find an existing OpenCode instance
+ * or spawn a new one, always opening it as an editor tab.
+ *
+ * Used by both `handleOpenNewInstance` (from the editor title button) and
+ * `handleOpenInOpencode` (from the Explorer context menu).
+ */
+export async function openOpencodeForWorkspace(
+  workspacePath: string,
+  connectionService: ConnectionService,
+  instanceManager: InstanceManager,
+  outputChannel: vscode.LogOutputChannel
+): Promise<void> {
+  await vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: 'OpenCode: Opening instance…',
+      cancellable: false,
+    },
+    async () => {
+      try {
+        // Check for an existing OpenCode process that serves this workspace
+        const existingPort = await connectionService.findPortForWorkspace(workspacePath);
+
+        if (existingPort !== undefined) {
+          // Try to show the tracked terminal (we already know about it)
+          const trackedTerminal = instanceManager.getTerminalForPort(existingPort);
+
+          if (trackedTerminal) {
+            outputChannel.info(
+              `[openOpencodeForWorkspace] Focusing tracked terminal for port ${existingPort}`
+            );
+            trackedTerminal.show(false);
+            vscode.window.setStatusBarMessage(
+              `$(check) Resumed OpenCode on port ${existingPort}`,
+              4000
+            );
+            return;
+          }
+
+          // Instance is running but no tracked terminal — open a new editor-tab
+          // terminal that re-attaches to the existing port
+          outputChannel.info(
+            `[openOpencodeForWorkspace] No tracked terminal for port ${existingPort}, opening editor tab`
+          );
+          await instanceManager.spawnInTerminal(existingPort, {
+            cwd: workspacePath,
+            asEditor: true,
+          });
+          vscode.window.setStatusBarMessage(
+            `$(check) Reconnected to OpenCode on port ${existingPort}`,
+            4000
+          );
+          return;
+        }
+
+        // No existing instance — spawn a fresh one for this workspace
+        outputChannel.info(
+          `[openOpencodeForWorkspace] No existing instance for "${workspacePath}", spawning new one`
+        );
+        const port = await instanceManager.findAvailablePort();
+        await instanceManager.spawnInTerminal(port, {
+          cwd: workspacePath,
+          asEditor: true,
+        });
+        outputChannel.info(`[openOpencodeForWorkspace] New instance started on port ${port}`);
+        vscode.window.setStatusBarMessage(`$(check) OpenCode started on port ${port}`, 4000);
+      } catch (err) {
+        outputChannel.error(`[openOpencodeForWorkspace] Failed: ${(err as Error).message}`);
+        await vscode.window.showErrorMessage(
+          `Failed to open OpenCode: ${(err as Error).message}`
+        );
+      }
+    }
+  );
+}
+
+/**
+ * Handle the "Open New Instance" editor title button command.
+ * Detects the workspace from the active editor file and delegates to openOpencodeForWorkspace.
+ */
+export async function handleOpenNewInstance(
+  connectionService: ConnectionService,
+  instanceManager: InstanceManager,
+  outputChannel: vscode.LogOutputChannel
+): Promise<void> {
+  const workspaceFolder = resolveActiveWorkspace();
+
+  if (!workspaceFolder) {
+    await vscode.window.showWarningMessage(
+      'OpenCode: No workspace folder detected. Open a project folder first.'
+    );
+    return;
+  }
+
+  outputChannel.info(`[openNewInstance] Target workspace: "${workspaceFolder.uri.fsPath}"`);
+  await openOpencodeForWorkspace(
+    workspaceFolder.uri.fsPath,
+    connectionService,
+    instanceManager,
+    outputChannel
+  );
+}

--- a/src/commands/sendPath.ts
+++ b/src/commands/sendPath.ts
@@ -21,7 +21,12 @@ export async function handleSendPath(
     return;
   }
 
-  const connected = await connectionService.ensureConnected();
+  // Use the workspace of the first selected resource to route to the correct instance.
+  const workspacePath = vscode.workspace.getWorkspaceFolder(resources[0])?.uri.fsPath;
+  const connected = workspacePath
+    ? await connectionService.ensureConnectedForWorkspace(workspacePath)
+    : await connectionService.ensureConnected();
+
   const openCodeClient = connectionService.getClient();
   const lastAutoSpawnError = connectionService.getLastAutoSpawnError();
 
@@ -35,7 +40,7 @@ export async function handleSendPath(
 
   try {
     const port = openCodeClient.getPort();
-    const workspaceDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || 'unknown';
+    const workspaceDir = workspacePath ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? 'unknown';
     const paths = formatPaths(resources);
 
     outputChannel.info(`[sendPath] Sending to port ${port}, cwd: ${workspaceDir}`);

--- a/src/commands/sendRelativePath.ts
+++ b/src/commands/sendRelativePath.ts
@@ -34,7 +34,12 @@ export async function handleSendRelativePath(
     return;
   }
 
-  const connected = await connectionService.ensureConnected();
+  // Use the workspace of the first selected resource to route to the correct instance.
+  const workspacePath = vscode.workspace.getWorkspaceFolder(resources[0])?.uri.fsPath;
+  const connected = workspacePath
+    ? await connectionService.ensureConnectedForWorkspace(workspacePath)
+    : await connectionService.ensureConnected();
+
   const openCodeClient = connectionService.getClient();
   const lastAutoSpawnError = connectionService.getLastAutoSpawnError();
 
@@ -48,7 +53,7 @@ export async function handleSendRelativePath(
 
   try {
     const port = openCodeClient.getPort();
-    const workspaceDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || 'unknown';
+    const workspaceDir = workspacePath ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? 'unknown';
     const paths = formatRelativePaths(resources);
 
     outputChannel.info(`[sendRelativePath] Sending to port ${port}, cwd: ${workspaceDir}`);

--- a/src/connection/connectionService.ts
+++ b/src/connection/connectionService.ts
@@ -188,6 +188,100 @@ export class ConnectionService {
   }
 
   /**
+   * Scan running OpenCode processes and return the port of the one serving the
+   * given workspace path. Does NOT modify any internal state.
+   *
+   * @param workspacePath - Filesystem path of the target workspace folder
+   * @returns port number of the matching instance, or undefined if none found
+   */
+  async findPortForWorkspace(workspacePath: string): Promise<number | undefined> {
+    const processes = await this.instanceManager.scanForProcesses();
+    const uniquePorts = [...new Set(processes.map(p => p.port))];
+
+    for (const port of uniquePorts) {
+      try {
+        const tempClient = new OpenCodeClient({ port, timeout: 3000, maxRetries: 0 });
+        const pathInfo = await tempClient.getPath();
+        tempClient.destroy();
+
+        this.outputChannel?.debug(
+          `[findPortForWorkspace] Port ${port} → "${pathInfo.directory}" vs target "${workspacePath}"`
+        );
+
+        if (pathsMatch(pathInfo.directory, workspacePath)) {
+          this.outputChannel?.info(
+            `[findPortForWorkspace] Matched port ${port} for workspace "${workspacePath}"`
+          );
+          return port;
+        }
+      } catch {
+        this.outputChannel?.debug(`[findPortForWorkspace] Port ${port} did not respond`);
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Ensure we're connected to the OpenCode instance that serves the given workspace path.
+   *
+   * Priority:
+   *  1. Current client — if it already serves this workspace, reuse it (fast path).
+   *  2. Process scan via findPortForWorkspace — swap the internal client when a match is found
+   *     so the status bar reflects the correct connection.
+   *  3. Fallback — delegates to ensureConnected() (handles auto-spawn, configured-port, etc.).
+   *
+   * @param workspacePath - Filesystem path of the target workspace folder
+   * @returns true if connected to an instance serving this workspace (or any instance as fallback)
+   */
+  async ensureConnectedForWorkspace(workspacePath: string): Promise<boolean> {
+    this.outputChannel?.info(`[ensureConnectedForWorkspace] Target: "${workspacePath}"`);
+
+    // 1. Fast path: check whether the current client already serves this workspace
+    if (this.client) {
+      try {
+        const alive = await this.client.testConnection();
+        if (alive) {
+          const pathInfo = await this.client.getPath();
+          if (pathsMatch(pathInfo.directory, workspacePath)) {
+            this.outputChannel?.debug(
+              '[ensureConnectedForWorkspace] Current client already serves this workspace'
+            );
+            return true;
+          }
+          this.outputChannel?.info(
+            `[ensureConnectedForWorkspace] Current client serves "${pathInfo.directory}", scanning for better match`
+          );
+        }
+      } catch {
+        // Client is dead — fall through to discovery
+      }
+    }
+
+    // 2. Scan for a process serving the target workspace
+    const port = await this.findPortForWorkspace(workspacePath);
+
+    if (port !== undefined) {
+      if (this.client) {
+        this.client.destroy();
+      }
+      this.client = new OpenCodeClient({ port });
+      this.connectedPort = port;
+      this.outputChannel?.info(
+        `[ensureConnectedForWorkspace] Switched to port ${port} for workspace "${workspacePath}"`
+      );
+      this._onDidChangeConnectionState.fire({ connected: true, port });
+      return true;
+    }
+
+    // 3. No workspace-specific instance found — fall back to generic connection
+    this.outputChannel?.info(
+      '[ensureConnectedForWorkspace] No matching instance found, falling back to ensureConnected()'
+    );
+    return this.ensureConnected();
+  }
+
+  /**
    * Ensure we're connected to an OpenCode instance.
    * Tries: current client → auto-discovery → auto-spawn → configured port.
    * @returns true if connected

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,8 +4,11 @@
  */
 import {
   handleAddMultipleFiles,
+  handleAddSelectionToPrompt,
   handleAddToPrompt,
   handleCheckInstance,
+  handleOpenInOpencode,
+  handleOpenNewInstance,
   handleSelectDefaultInstance,
   handleSendDebugContext,
   handleSendPath,
@@ -191,6 +194,31 @@ function registerCommands(): void {
     }
   );
 
+  // Add selection/file reference to OpenCode prompt (editor context menu)
+  const instanceManager = InstanceManager.getInstance();
+  const addSelectionToPromptCommand = vscode.commands.registerCommand(
+    'opencodeConnector.addSelectionToPrompt',
+    async () => handleAddSelectionToPrompt(connectionService!, outputChannel!)
+  );
+
+  // Open a new OpenCode instance as an editor tab in the correct workspace
+  const openNewInstanceCommand = vscode.commands.registerCommand(
+    'opencodeConnector.openNewInstance',
+    async () => handleOpenNewInstance(connectionService!, instanceManager, outputChannel!)
+  );
+
+  // Open in OpenCode — Explorer context menu (right-click file or folder)
+  const openInOpencodeCommand = vscode.commands.registerCommand(
+    'opencodeConnector.openInOpencode',
+    async (uri: vscode.Uri, _selectedUris: vscode.Uri[]) => {
+      // uri is the right-clicked item; fall back to active editor if somehow undefined
+      const target = uri ?? vscode.window.activeTextEditor?.document.uri;
+      if (target) {
+        await handleOpenInOpencode(connectionService!, instanceManager, outputChannel!, target);
+      }
+    }
+  );
+
   // Push all subscriptions for cleanup
   extensionContext?.subscriptions?.push(
     statusCommand,
@@ -201,7 +229,10 @@ function registerCommands(): void {
     selectDefaultInstanceCommand,
     sendDebugContextCommand,
     sendPathCommand,
-    sendRelativePathCommand
+    sendRelativePathCommand,
+    addSelectionToPromptCommand,
+    openNewInstanceCommand,
+    openInOpencodeCommand
   );
 }
 

--- a/src/instance/instanceManager.ts
+++ b/src/instance/instanceManager.ts
@@ -83,6 +83,16 @@ export interface DiscoveredProcess {
 }
 
 /**
+ * Options for spawning an OpenCode terminal.
+ */
+export interface SpawnTerminalOptions {
+  /** Working directory for the terminal (defaults to the primary workspace path) */
+  cwd?: string;
+  /** When true, opens the terminal as an editor tab instead of the terminal panel */
+  asEditor?: boolean;
+}
+
+/**
  * Logger interface for extension logging
  */
 export interface Logger {
@@ -569,18 +579,38 @@ export class InstanceManager {
   }
 
   /**
-   * Spawn an OpenCode instance in a VSCode Integrated Terminal
+   * Get the terminal tracked for a specific port, if any.
+   * @param port - Port number to look up
+   * @returns The tracked terminal, or undefined if not found
+   */
+  public getTerminalForPort(port: number): vscode.Terminal | undefined {
+    return this.portToTerminal.get(port);
+  }
+
+  /**
+   * Spawn an OpenCode instance in a VSCode Integrated Terminal.
    * @param port - Port number to use for the instance
+   * @param options - Optional spawn options (cwd, asEditor)
    * @returns Promise<void>
    */
-  public async spawnInTerminal(port: number): Promise<void> {
-    const workspacePath = this.getWorkspacePath();
+  public async spawnInTerminal(port: number, options?: SpawnTerminalOptions): Promise<void> {
+    const workspacePath = options?.cwd ?? this.getWorkspacePath();
     const workspaceHash = WorkspaceUtils.getWorkspaceHash(workspacePath);
     const terminalName = `OpenCode: ${workspaceHash}`;
     const binaryPath = this.configManager.getBinaryPath() || 'opencode';
     // Don't use getCommandWithExtension here — the integrated terminal shell
     // resolves binaries via PATH naturally (handles .exe, aliases, etc.)
     const fullCommand = `${binaryPath} --port ${port}`;
+
+    // Build terminal creation options
+    const terminalCreationOptions: vscode.TerminalOptions = {
+      name: terminalName,
+      cwd: workspacePath,
+    };
+
+    if (options?.asEditor) {
+      terminalCreationOptions.location = vscode.TerminalLocation.Editor;
+    }
 
     // Check for existing terminal with the same name
     const existingTerminal = vscode.window.terminals.find(t => t.name === terminalName);
@@ -600,7 +630,7 @@ export class InstanceManager {
       this.portToTerminal.set(port, existingTerminal);
     } else {
       // Create a new terminal, make it visible and focused
-      const terminal = vscode.window.createTerminal({ name: terminalName });
+      const terminal = vscode.window.createTerminal(terminalCreationOptions);
       terminal.show(false);
 
       // Wait for shell to initialize before sending the command

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -50,7 +50,7 @@ export function formatPaths(resources: { fsPath: string }[]): string {
  * @returns Formatted path string with @ prefix and trailing slash for directories
  */
 export function formatRelativePath(relativePath: string, isDir: boolean): string {
-  let formatted = '@' + relativePath;
+  let formatted = '@' + relativePath.replace(/\//g, path.sep);
   if (isDir) {
     formatted += path.sep;
   }

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -3,6 +3,7 @@
  * Handles workspace root detection and multi-root workspace support
  */
 import * as crypto from 'crypto';
+import * as path from 'path';
 import * as vscode from 'vscode';
 
 /**
@@ -218,7 +219,8 @@ export const WorkspaceUtils = {
     }
 
     const relativePath = vscode.workspace.asRelativePath(document.uri);
-    let ref = `@${relativePath}`;
+    const normalizedPath = relativePath.replace(/\//g, path.sep);
+    let ref = `@${normalizedPath}`;
 
     const selection = activeEditor.selection;
     if (!selection.isEmpty) {


### PR DESCRIPTION
## Summary

- **Workspace-aware routing**: all send commands now resolve the correct OpenCode instance for the active file's workspace folder — multi-root workspaces are fully supported without any manual switching.
- **Editor integration**: new title bar button opens OpenCode as an editor tab (`TerminalLocation.Editor`); new right-click command sends the selected code range as `@file#L10-L20`.
- **Explorer integration**: new _Open in OpenCode_ entry in the `navigation` group launches or re-attaches an instance for any folder.
- **Windows fix**: `formatRelativePath` and `getActiveFileRef` now normalize path separators using `path.sep` instead of always producing forward slashes.

## New commands

| Command ID | Entry point | Description |
|---|---|---|
| `opencodeConnector.addSelectionToPrompt` | Editor right-click (requires selection) | Sends selected range as `@file#L10-L20` |
| `opencodeConnector.openNewInstance` | Editor title bar button | Opens OpenCode as editor tab for current workspace |
| `opencodeConnector.openInOpencode` | Explorer right-click → navigation group | Opens OpenCode as editor tab for selected folder's workspace |

## Changes

| File | Change |
|---|---|
| `src/commands/addSelectionToPrompt.ts` | New command |
| `src/commands/openNewInstance.ts` | New command + `openOpencodeForWorkspace()` shared helper |
| `src/commands/openInOpencode.ts` | New command |
| `src/connection/connectionService.ts` | Added `findPortForWorkspace()` + rewrote `ensureConnectedForWorkspace()` |
| `src/instance/instanceManager.ts` | Added `SpawnTerminalOptions` (`asEditor`, `cwd`), `getTerminalForPort()`, updated `spawnInTerminal()` |
| `src/commands/addToPrompt.ts` | Uses `ensureConnectedForWorkspace()` |
| `src/commands/addMultipleFiles.ts` | Uses `ensureConnectedForWorkspace()` |
| `src/commands/sendPath.ts` | Uses `ensureConnectedForWorkspace()` |
| `src/commands/sendRelativePath.ts` | Uses `ensureConnectedForWorkspace()` |
| `src/commands/index.ts` | Exports new handlers |
| `src/extension.ts` | Registers 3 new commands |
| `src/utils/pathUtils.ts` | Windows `path.sep` normalization |
| `src/utils/workspace.ts` | Windows `path.sep` normalization |
| `package.json` | Declares new commands + menu entries (`editor/context`, `editor/title`, `explorer/context`) |
| `README.md` | Documents all new features |
| `CHANGELOG.md` | Entry for v1.2.1 |

## Test plan

- [x] `npm run compile` — builds without errors
- [x] `npm run lint` — no ESLint errors
- [x] `npm run format:check` — formatting consistent
- [x] Packaged as `.vsix` and manually verified in VS Code
