### PR TITLE
fix: register opencode.explainAndFix command

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,10 @@
         "icon": "$(terminal-tmux)"
       },
       {
+        "command": "opencode.explainAndFix",
+        "title": "Explain and Fix (OpenCode)"
+      },
+      {
         "command": "opencodeConnector.openInOpencode",
         "title": "Open in OpenCode",
         "icon": "$(terminal-tmux)"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import {
   handleAddSelectionToPrompt,
   handleAddToPrompt,
   handleCheckInstance,
+  handleExplainAndFix,
   handleOpenInOpencode,
   handleOpenNewInstance,
   handleSelectDefaultInstance,
@@ -185,6 +186,13 @@ export function registerCommands(): void {
     }
   );
 
+  const explainAndFixCommand = vscode.commands.registerCommand(
+    'opencode.explainAndFix',
+    async (diagnostic: vscode.Diagnostic, uri: vscode.Uri) => {
+      await handleExplainAndFix(connectionService!, outputChannel!, diagnostic, uri);
+    }
+  );
+
   extensionContext?.subscriptions?.push(
     statusCommand,
     workspaceCommand,
@@ -197,7 +205,8 @@ export function registerCommands(): void {
     sendRelativePathCommand,
     addSelectionToPromptCommand,
     openNewInstanceCommand,
-    openInOpencodeCommand
+    openInOpencodeCommand,
+    explainAndFixCommand
   );
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -189,6 +189,16 @@ export function registerCommands(): void {
   const explainAndFixCommand = vscode.commands.registerCommand(
     'opencode.explainAndFix',
     async (diagnostic: vscode.Diagnostic, uri: vscode.Uri) => {
+      if (!diagnostic || !uri) {
+        outputChannel?.warn(
+          'Explain and Fix requires a diagnostic context. Run it from a code action on an editor diagnostic.'
+        );
+        await vscode.window.showInformationMessage(
+          'Explain and Fix works from a diagnostic quick fix. Place cursor on an issue and run the lightbulb action.'
+        );
+        return;
+      }
+
       await handleExplainAndFix(connectionService!, outputChannel!, diagnostic, uri);
     }
   );


### PR DESCRIPTION
The code action provider referenced `opencode.explainAndFix` as the command to execute, but it was never registered with `vscode.commands.registerCommand` in `extension.ts`, nor declared in `package.json`'s `contributes.commands`. This caused a 'command not found' error when users clicked the 'Explain and Fix (OpenCode)' quick fix.

**Changes:**
- Registered `opencode.explainAndFix` command in `registerCommands()` wired to the existing `handleExplainAndFix` handler
- Declared the command in `package.json` `contributes.commands` for extension metadata completeness