### PR TITLE
feat: notify when OpenCode sessions return to idle

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,6 +4,7 @@
   "printWidth": 100,
   "singleQuote": true,
   "trailingComma": "es5",
+  "endOfLine": "auto",
   "bracketSpacing": true,
   "arrowParens": "avoid",
   "plugins": ["@trivago/prettier-plugin-sort-imports"],

--- a/package.json
+++ b/package.json
@@ -76,6 +76,10 @@
         "command": "opencodeConnector.openInOpencode",
         "title": "Open in OpenCode",
         "icon": "$(terminal-tmux)"
+      },
+      {
+        "command": "opencodeConnector.toggleNotifications",
+        "title": "OpenCode: Toggle Notifications"
       }
     ],
     "keybindings": [
@@ -137,6 +141,11 @@
           "type": "boolean",
           "default": true,
           "description": "Automatically focus OpenCode terminal after sending prompts"
+        },
+        "opencode.notificationsEnabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show VS Code notifications when the active OpenCode runtime returns to idle after work"
         }
       }
     },

--- a/src/api/openCodeClient.ts
+++ b/src/api/openCodeClient.ts
@@ -57,6 +57,15 @@ const DEFAULT_CONFIG: Required<OpenCodeClientConfig> = {
 };
 
 /**
+ * Build the OpenCode event-stream URL for a runtime port.
+ * @param port - Runtime port to target
+ * @returns Absolute SSE endpoint URL
+ */
+export function getEventUrl(port: number = DEFAULT_CONFIG.port): string {
+  return `http://${DEFAULT_CONFIG.host}:${port}/event`;
+}
+
+/**
  * OpenCode HTTP Client
  * Provides typed methods for communicating with OpenCode API
  */

--- a/src/api/openCodeEventClient.ts
+++ b/src/api/openCodeEventClient.ts
@@ -1,0 +1,264 @@
+import { SSEEvent, SessionStatusEvent } from '../types';
+import { getEventUrl } from './openCodeClient';
+
+import * as http from 'http';
+import * as https from 'https';
+import { URL } from 'url';
+
+/**
+ * Callbacks emitted by the event-stream client.
+ */
+export interface OpenCodeEventClientCallbacks {
+  /** Handles parsed SSE events from OpenCode. */
+  onEvent(event: SSEEvent | SessionStatusEvent): void;
+  /** Handles unexpected stream termination. */
+  onDisconnect(error?: Error): void;
+}
+
+/**
+ * Raw stream handlers provided to the low-level transport.
+ */
+export interface OpenCodeEventStreamHandlers {
+  /** Handles raw text chunks from the event stream. */
+  onChunk(chunk: string): void;
+  /** Handles stream termination from the transport. */
+  onDisconnect(error?: Error): void;
+}
+
+/**
+ * Active SSE stream connection.
+ */
+export interface OpenCodeEventStreamConnection {
+  /** Close the underlying stream connection. */
+  close(): void;
+}
+
+interface Logger {
+  info(message: string): void;
+  warn(message: string): void;
+  error(message: string): void;
+}
+
+/**
+ * Factory contract used to open an SSE stream.
+ */
+export type OpenCodeEventStreamFactory = (
+  url: string,
+  handlers: OpenCodeEventStreamHandlers
+) => OpenCodeEventStreamConnection;
+
+interface OpenCodeEventClientDependencies {
+  createStream?: OpenCodeEventStreamFactory;
+  logger?: Logger;
+}
+
+const NOOP_LOGGER: Logger = {
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+};
+
+/**
+ * SSE client for the OpenCode `/event` endpoint.
+ */
+export class OpenCodeEventClient {
+  private readonly createStream: OpenCodeEventStreamFactory;
+  private readonly logger: Logger;
+  private connection: OpenCodeEventStreamConnection | undefined;
+  private buffer = '';
+  private stopped = true;
+  private generation = 0;
+
+  /**
+   * Create a new SSE client.
+   * @param callbacks - Event and disconnect callbacks
+   * @param dependencies - Optional transport overrides for testing
+   */
+  constructor(
+    private readonly callbacks: OpenCodeEventClientCallbacks,
+    dependencies: OpenCodeEventClientDependencies = {}
+  ) {
+    this.createStream = dependencies.createStream ?? createNodeEventStream;
+    this.logger = dependencies.logger ?? NOOP_LOGGER;
+  }
+
+  /**
+   * Start listening on the provided runtime port.
+   * @param port - Active OpenCode runtime port
+   */
+  public start(port: number): void {
+    this.stop();
+    this.stopped = false;
+    this.buffer = '';
+    // Capture a per-connection generation so a late/asynchronous disconnect
+    // from a previous connection (e.g. ECONNRESET after request.destroy())
+    // cannot clobber the current connection or trigger a spurious reconnect.
+    const generation = ++this.generation;
+    this.connection = this.createStream(getEventUrl(port), {
+      onChunk: chunk => this.handleChunk(chunk),
+      onDisconnect: error => {
+        if (generation !== this.generation) {
+          // Stale disconnect from a connection that has already been replaced
+          // by a newer start() (or torn down by stop()). Ignore it entirely.
+          return;
+        }
+
+        this.connection = undefined;
+        this.buffer = '';
+
+        if (!this.stopped) {
+          this.callbacks.onDisconnect(error);
+        }
+      },
+    });
+  }
+
+  /**
+   * Stop the current event-stream connection.
+   */
+  public stop(): void {
+    this.stopped = true;
+    this.buffer = '';
+    this.connection?.close();
+    this.connection = undefined;
+  }
+
+  private handleChunk(chunk: string): void {
+    this.logger.info(`Raw SSE chunk (${chunk.length} chars): ${JSON.stringify(chunk)}`);
+    this.buffer += chunk;
+
+    while (true) {
+      const boundary = this.findFrameBoundary();
+      if (!boundary) {
+        return;
+      }
+
+      const rawFrame = this.buffer.slice(0, boundary.index);
+      this.buffer = this.buffer.slice(boundary.index + boundary.length);
+      this.emitFrame(rawFrame);
+    }
+  }
+
+  /**
+   * Locate the next SSE frame boundary in the buffer, supporting both LF (`\n\n`)
+   * and CRLF (`\r\n\r\n`) separators. Returns the earliest boundary along with the
+   * length of the separator to consume.
+   */
+  private findFrameBoundary(): { index: number; length: number } | undefined {
+    const lfIndex = this.buffer.indexOf('\n\n');
+    const crlfIndex = this.buffer.indexOf('\r\n\r\n');
+
+    if (lfIndex === -1 && crlfIndex === -1) {
+      return undefined;
+    }
+
+    // Prefer the CRLF boundary when it is not later than the LF boundary so the
+    // full `\r\n\r\n` separator (including the leading `\r`) is consumed.
+    if (crlfIndex !== -1 && (lfIndex === -1 || crlfIndex <= lfIndex)) {
+      return { index: crlfIndex, length: 4 };
+    }
+
+    return { index: lfIndex, length: 2 };
+  }
+
+  private emitFrame(rawFrame: string): void {
+    this.logger.info(`Raw SSE frame (${rawFrame.length} chars): ${JSON.stringify(rawFrame)}`);
+
+    const lines = rawFrame.split(/\r?\n/);
+    const data = rawFrame
+      .split(/\r?\n/)
+      .filter(line => line.startsWith('data:'))
+      .map(line => line.slice('data:'.length).trim())
+      .join('\n');
+
+    const sseEventName =
+      lines
+        .find(line => line.startsWith('event:'))
+        ?.slice('event:'.length)
+        .trim() || 'message';
+
+    if (!lines.some(line => line.startsWith('event:'))) {
+      this.logger.info(
+        `SSE frame omitted event line; defaulting to SSE event "message": ${JSON.stringify(rawFrame)}`
+      );
+    }
+
+    if (!data) {
+      this.logger.warn(`Ignoring SSE frame without data payload: ${JSON.stringify(rawFrame)}`);
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(data) as Record<string, unknown>;
+      const domainType = typeof parsed.type === 'string' ? parsed.type : undefined;
+      const properties = parsed.properties;
+
+      if (!domainType || typeof properties !== 'object' || properties === null) {
+        this.logger.warn(`Ignoring malformed SSE frame payload: ${JSON.stringify(parsed)}`);
+        return;
+      }
+
+      this.logger.info(
+        `Parsed OpenCode event: ${JSON.stringify({
+          sseEvent: sseEventName,
+          type: domainType,
+          properties,
+        })}`
+      );
+      this.callbacks.onEvent({
+        type: domainType,
+        properties: properties as Record<string, unknown>,
+      });
+    } catch {
+      this.logger.warn(`Ignoring malformed SSE frame: ${JSON.stringify(rawFrame)}`);
+    }
+  }
+}
+
+/**
+ * Open an SSE stream using Node's native HTTP(S) clients.
+ * @param urlString - Absolute event-stream URL
+ * @param handlers - Transport event handlers
+ * @returns Active stream connection
+ */
+export function createNodeEventStream(
+  urlString: string,
+  handlers: OpenCodeEventStreamHandlers
+): OpenCodeEventStreamConnection {
+  const url = new URL(urlString);
+  const transport = url.protocol === 'https:' ? https : http;
+  const request = transport.request(
+    url,
+    {
+      method: 'GET',
+      headers: {
+        Accept: 'text/event-stream',
+      },
+    },
+    response => {
+      response.setEncoding('utf8');
+      response.on('data', chunk => {
+        handlers.onChunk(chunk);
+      });
+      response.on('end', () => {
+        handlers.onDisconnect();
+      });
+      response.on('error', error => {
+        handlers.onDisconnect(error);
+      });
+    }
+  );
+
+  request.on('error', error => {
+    handlers.onDisconnect(error);
+  });
+  request.end();
+
+  return {
+    close: () => {
+      request.destroy();
+    },
+  };
+}
+
+export default OpenCodeEventClient;

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -11,3 +11,4 @@ export { handleSendRelativePath } from './sendRelativePath';
 export { handleAddSelectionToPrompt } from './addSelectionToPrompt';
 export { handleOpenNewInstance } from './openNewInstance';
 export { handleOpenInOpencode } from './openInOpencode';
+export { handleToggleNotifications } from './toggleNotifications';

--- a/src/commands/openNewInstance.ts
+++ b/src/commands/openNewInstance.ts
@@ -44,6 +44,8 @@ export async function openOpencodeForWorkspace(
               `[openOpencodeForWorkspace] Focusing tracked terminal for port ${existingPort}`
             );
             trackedTerminal.show(false);
+            // Attach so status bar + notifications track this already-running instance.
+            await connectionService.connectToKnownPort(existingPort);
             vscode.window.setStatusBarMessage(
               `$(check) Resumed OpenCode on port ${existingPort}`,
               4000
@@ -58,6 +60,7 @@ export async function openOpencodeForWorkspace(
             cwd: workspacePath,
             asEditor: true,
           });
+          await connectionService.connectToKnownPort(existingPort);
           vscode.window.setStatusBarMessage(
             `$(check) Reconnected to OpenCode on port ${existingPort}`,
             4000
@@ -74,6 +77,9 @@ export async function openOpencodeForWorkspace(
           asEditor: true,
         });
         outputChannel.info(`[openOpencodeForWorkspace] New instance started on port ${port}`);
+        // Attach to the freshly spawned instance so the connection state fires and
+        // the notification listener arms on this known port (no discovery needed).
+        await connectionService.connectToKnownPort(port);
         vscode.window.setStatusBarMessage(`$(check) OpenCode started on port ${port}`, 4000);
       } catch (err) {
         outputChannel.error(`[openOpencodeForWorkspace] Failed: ${(err as Error).message}`);

--- a/src/commands/toggleNotifications.ts
+++ b/src/commands/toggleNotifications.ts
@@ -1,0 +1,29 @@
+import { ConfigManager } from '../config';
+
+import * as vscode from 'vscode';
+
+/**
+ * Toggle OpenCode completion notifications on or off.
+ * @param configManager - Extension configuration manager
+ * @param outputChannel - User-visible log channel
+ */
+export async function handleToggleNotifications(
+  configManager: ConfigManager,
+  outputChannel: vscode.LogOutputChannel
+): Promise<void> {
+  const nextValue = !configManager.getNotificationsEnabled();
+
+  try {
+    await configManager.setNotificationsEnabled(nextValue);
+    outputChannel.info(`OpenCode notifications ${nextValue ? 'enabled' : 'disabled'}.`);
+    await vscode.window.showInformationMessage(
+      `OpenCode notifications ${nextValue ? 'enabled' : 'disabled'}.`
+    );
+  } catch (err) {
+    const message = `Failed to toggle notifications: ${(err as Error).message}`;
+    outputChannel.error(message);
+    await vscode.window.showErrorMessage(message);
+  }
+}
+
+export default handleToggleNotifications;

--- a/src/config.ts
+++ b/src/config.ts
@@ -50,6 +50,15 @@ export class ConfigManager {
   }
 
   /**
+   * Get OpenCode notifications enabled setting.
+   * @returns Whether completion notifications are enabled (default: true)
+   */
+  public getNotificationsEnabled(): boolean {
+    const config = vscode.workspace.getConfiguration('opencode');
+    return config.get<boolean>('notificationsEnabled') ?? true;
+  }
+
+  /**
    * Set OpenCode server port.
    * @param port - Port number to use
    */
@@ -68,6 +77,15 @@ export class ConfigManager {
   }
 
   /**
+   * Set OpenCode notifications enabled setting.
+   * @param enabled - Whether completion notifications should be enabled
+   */
+  public setNotificationsEnabled(enabled: boolean): Thenable<void> {
+    const config = vscode.workspace.getConfiguration('opencode');
+    return config.update('notificationsEnabled', enabled, vscode.ConfigurationTarget.Global);
+  }
+
+  /**
    * Get default configuration values.
    * @returns Object containing default values
    */
@@ -76,12 +94,14 @@ export class ConfigManager {
     binaryPath: string;
     codeActionSeverityLevels: string[];
     autoFocusTerminal: boolean;
+    notificationsEnabled: boolean;
   } {
     return {
       port: 4096,
       binaryPath: '',
       codeActionSeverityLevels: ['error', 'warning', 'information', 'hint'],
       autoFocusTerminal: true,
+      notificationsEnabled: true,
     };
   }
 

--- a/src/connection/connectionService.ts
+++ b/src/connection/connectionService.ts
@@ -45,6 +45,35 @@ export class ConnectionService {
   }
 
   /**
+   * Replace the active client and emit the latest connection state.
+   * @param port - Active runtime port
+   */
+  private setActiveConnection(port: number): void {
+    if (this.client) {
+      this.client.destroy();
+    }
+
+    this.client = new OpenCodeClient({ port });
+    this.connectedPort = port;
+    this._onDidChangeConnectionState.fire({ connected: true, port });
+  }
+
+  /**
+   * Clear the active client and emit a disconnected state when needed.
+   */
+  private clearActiveConnection(): void {
+    if (this.client) {
+      this.client.destroy();
+      this.client = undefined;
+    }
+
+    if (this.connectedPort !== undefined) {
+      this.connectedPort = undefined;
+      this._onDidChangeConnectionState.fire({ connected: false });
+    }
+  }
+
+  /**
    * Discover a running OpenCode instance serving the current workspace directory.
    * Scans running processes, verifies each with GET /path, and matches against workspace CWD.
    * If a match is found, creates/updates the global client to use that port.
@@ -90,11 +119,7 @@ export class ConnectionService {
           if (pathsMatch(pathInfo.directory, workspaceDir)) {
             foundMatchingProcess = true;
             if (this.connectedPort !== port) {
-              if (this.client) {
-                this.client.destroy();
-              }
-              this.client = new OpenCodeClient({ port });
-              this.connectedPort = port;
+              this.setActiveConnection(port);
 
               this.outputChannel?.info(
                 `OpenCode Connector: auto-connected to instance on port ${port}`
@@ -187,13 +212,8 @@ export class ConnectionService {
     const port = await this.findPortForWorkspace(workspacePath);
 
     if (port !== undefined) {
-      if (this.client) {
-        this.client.destroy();
-      }
-      this.client = new OpenCodeClient({ port });
-      this.connectedPort = port;
+      this.setActiveConnection(port);
       this.outputChannel?.info(`Switched to port ${port} for workspace "${workspacePath}"`);
-      this._onDidChangeConnectionState.fire({ connected: true, port });
       return true;
     }
 
@@ -223,14 +243,9 @@ export class ConnectionService {
             tempClient.destroy();
 
             if (pathsMatch(pathInfo.directory, currentWorkspaceDir)) {
-              if (this.client) {
-                this.client.destroy();
-              }
-              this.client = new OpenCodeClient({ port: defaultPort });
-              this.connectedPort = defaultPort;
+              this.setActiveConnection(defaultPort);
 
               this.outputChannel?.info(`Using default instance on port ${defaultPort}`);
-              this._onDidChangeConnectionState.fire({ connected: true, port: defaultPort });
               return true;
             }
             this.outputChannel?.info(
@@ -262,19 +277,17 @@ export class ConnectionService {
               this._onDidChangeConnectionState.fire({ connected: true, port: this.connectedPort });
               return true;
             }
-            this.client.destroy();
-            this.client = undefined;
-            this.connectedPort = undefined;
+            this.clearActiveConnection();
           }
         }
       } catch {
         // Current client is dead, try discovery
+        this.clearActiveConnection();
       }
     }
 
     const discovered = await this.discoverAndConnect();
     if (discovered) {
-      this._onDidChangeConnectionState.fire({ connected: true, port: this.connectedPort });
       return true;
     }
 
@@ -290,13 +303,11 @@ export class ConnectionService {
         if (this.client) {
           this.client.destroy();
         }
-        this.client = new OpenCodeClient({ port });
-        this.connectedPort = port;
+        this.setActiveConnection(port);
 
         this.outputChannel?.info(
           `OpenCode Connector: spawned and connected to instance on port ${port}`
         );
-        this._onDidChangeConnectionState.fire({ connected: true, port });
         return true;
       } else {
         this.lastAutoSpawnError = `Spawned OpenCode on port ${port} but it did not become ready within 30s. Check the "OpenCode" terminal for errors.`;
@@ -306,23 +317,71 @@ export class ConnectionService {
     }
 
     const port = this.configManager.getPort() ?? 4096;
-    if (!this.client || this.client.getPort() !== port) {
-      if (this.client) {
-        this.client.destroy();
-      }
-      this.client = new OpenCodeClient({ port });
-      this.connectedPort = port;
+    let candidateClient = this.client;
+    if (!candidateClient || candidateClient.getPort() !== port) {
+      candidateClient = new OpenCodeClient({ port });
     }
 
     try {
-      const connected = await this.client.testConnection();
+      const connected = await candidateClient.testConnection();
       if (connected) {
-        this._onDidChangeConnectionState.fire({ connected: true, port });
+        if (candidateClient !== this.client) {
+          // setActiveConnection already emits the connected state exactly once.
+          this.setActiveConnection(port);
+        } else {
+          this.connectedPort = port;
+          this._onDidChangeConnectionState.fire({ connected: true, port });
+        }
+      } else {
+        if (candidateClient !== this.client) {
+          candidateClient.destroy();
+        }
+        this.clearActiveConnection();
       }
       return connected;
     } catch {
+      if (candidateClient !== this.client) {
+        candidateClient.destroy();
+      }
+      this.clearActiveConnection();
       return false;
     }
+  }
+
+  /**
+   * Attach to an OpenCode instance on a port we already know (for example one
+   * we just spawned or focused via "Open in OpenCode"). Waits for the server to
+   * accept requests, then promotes it to the active connection and emits the
+   * connected state so dependent services (status bar, notifications) wire up.
+   *
+   * Unlike ensureConnected(), this never scans processes nor auto-spawns, so it
+   * establishes a monitored connection even when process/port discovery is
+   * unavailable on the host.
+   *
+   * @param port - Known runtime port to attach to
+   * @param waitForReady - Wait for the server to become ready first (default: true)
+   * @returns true once attached, false if the server never responded
+   */
+  async connectToKnownPort(port: number, waitForReady: boolean = true): Promise<boolean> {
+    if (waitForReady) {
+      const ready = await this.waitForServer(port);
+      if (!ready) {
+        this.outputChannel?.warn(
+          `Known OpenCode instance on port ${port} did not become ready; not attaching`
+        );
+        return false;
+      }
+    }
+
+    if (this.connectedPort === port && this.client) {
+      // Already attached — re-emit so late subscribers re-sync to this port.
+      this._onDidChangeConnectionState.fire({ connected: true, port });
+      return true;
+    }
+
+    this.setActiveConnection(port);
+    this.outputChannel?.info(`Attached to OpenCode instance on known port ${port}`);
+    return true;
   }
 
   getClient(): OpenCodeClient | undefined {
@@ -361,12 +420,9 @@ export class ConnectionService {
    * Disconnect from the current OpenCode instance.
    */
   disconnect(): void {
-    if (this.client) {
-      this.client.destroy();
-      this.client = undefined;
-      this.connectedPort = undefined;
+    if (this.client || this.connectedPort !== undefined) {
+      this.clearActiveConnection();
       this.outputChannel?.info('OpenCode Connector: disconnected');
-      this._onDidChangeConnectionState.fire({ connected: false });
     }
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,12 +15,14 @@ import {
   handleSendPath,
   handleSendRelativePath,
   handleShowWorkspace,
+  handleToggleNotifications,
   showStatusBarMenu,
 } from './commands';
 import { ConfigManager } from './config';
 import { ConnectionService, isRemoteSession } from './connection/connectionService';
 import { DefaultInstanceManager } from './instance/defaultInstanceManager';
 import { InstanceManager } from './instance/instanceManager';
+import { NotificationService } from './notifications/notificationService';
 import { OpenCodeCodeActionProvider } from './providers/codeActionProvider';
 import { StatusBarManager } from './statusBar';
 import { WorkspaceUtils } from './utils/workspace';
@@ -32,6 +34,7 @@ let connectionService: ConnectionService | undefined;
 let extensionContext: vscode.ExtensionContext | undefined;
 let statusBarManager: StatusBarManager | undefined;
 let outputChannel: vscode.LogOutputChannel | undefined;
+let notificationService: NotificationService | undefined;
 
 export function activate(extensionUri: vscode.Uri, context: vscode.ExtensionContext): void {
   extensionContext = context;
@@ -60,6 +63,7 @@ export function activate(extensionUri: vscode.Uri, context: vscode.ExtensionCont
 
     // Initialize connection service
     connectionService = new ConnectionService(configManager, instanceManager, outputChannel);
+    notificationService = new NotificationService(configManager, outputChannel);
 
     // Initialize status bar manager for connection status
     statusBarManager = StatusBarManager.getInstance();
@@ -68,6 +72,7 @@ export function activate(extensionUri: vscode.Uri, context: vscode.ExtensionCont
     // Subscribe to connection state changes FIRST (before other init that might fail)
     const connectionStateSub = connectionService.onDidChangeConnectionState(event => {
       statusBarManager?.updateConnectionStatus(event.connected, event.port);
+      notificationService?.syncConnection(event.connected ? event.port : undefined);
     });
     extensionContext?.subscriptions?.push(connectionStateSub);
 
@@ -89,6 +94,9 @@ export function activate(extensionUri: vscode.Uri, context: vscode.ExtensionCont
       .discoverAndConnect()
       .then(connected => {
         statusBarManager?.updateConnectionStatus(connected, connectionService?.getPort());
+        if (connected) {
+          notificationService?.syncConnection(connectionService?.getPort());
+        }
       })
       .catch(() => {
         statusBarManager?.updateConnectionStatus(false);
@@ -203,6 +211,11 @@ export function registerCommands(): void {
     }
   );
 
+  const toggleNotificationsCommand = vscode.commands.registerCommand(
+    'opencodeConnector.toggleNotifications',
+    async () => handleToggleNotifications(configManager!, outputChannel!)
+  );
+
   extensionContext?.subscriptions?.push(
     statusCommand,
     workspaceCommand,
@@ -216,7 +229,8 @@ export function registerCommands(): void {
     addSelectionToPromptCommand,
     openNewInstanceCommand,
     openInOpencodeCommand,
-    explainAndFixCommand
+    explainAndFixCommand,
+    toggleNotificationsCommand
   );
 }
 
@@ -234,6 +248,13 @@ export function registerWorkspaceHandlers(): void {
     if (event.affectsConfiguration('opencode')) {
       outputChannel?.info('OpenCode configuration changed');
     }
+
+    // Only reload the notification listener when its own setting changes.
+    // Reloading resets in-flight stream state, so unrelated settings (port,
+    // binaryPath, autoFocusTerminal, ...) must not trigger it.
+    if (event.affectsConfiguration('opencode.notificationsEnabled')) {
+      notificationService?.reloadSettings();
+    }
   });
 
   extensionContext?.subscriptions?.push(workspaceFoldersChange, configChange);
@@ -248,6 +269,11 @@ export function deactivate(): void {
       client.destroy();
     }
     connectionService = undefined;
+  }
+
+  if (notificationService) {
+    notificationService.dispose();
+    notificationService = undefined;
   }
 
   InstanceManager.resetInstance();

--- a/src/notifications/notificationService.ts
+++ b/src/notifications/notificationService.ts
@@ -1,0 +1,249 @@
+import { OpenCodeEventClient, OpenCodeEventClientCallbacks } from '../api/openCodeEventClient';
+import { SessionStatusEvent } from '../types';
+
+import * as vscode from 'vscode';
+
+interface Logger {
+  info(message: string): void;
+  warn(message: string): void;
+  error(message: string): void;
+}
+
+interface NotificationConfig {
+  getNotificationsEnabled(): boolean;
+}
+
+interface NotificationServiceDependencies {
+  createEventClient?: (
+    callbacks: OpenCodeEventClientCallbacks
+  ) => Pick<OpenCodeEventClient, 'start' | 'stop'>;
+  reconnectDelayMs?: number;
+  maxReconnectDelayMs?: number;
+  cooldownMs?: number;
+  now?: () => number;
+}
+
+const DEFAULT_RECONNECT_DELAY_MS = 1000;
+const DEFAULT_MAX_RECONNECT_DELAY_MS = 8000;
+const DEFAULT_IDLE_COOLDOWN_MS = 1500;
+
+/**
+ * Manages OpenCode task completion notifications for the active runtime port.
+ */
+export class NotificationService {
+  private readonly createEventClient: NotificationServiceDependencies['createEventClient'];
+  private readonly reconnectDelayMs: number;
+  private readonly maxReconnectDelayMs: number;
+  private readonly cooldownMs: number;
+  private readonly now: () => number;
+  private readonly eventClient: Pick<OpenCodeEventClient, 'start' | 'stop'>;
+  private activePort: number | undefined;
+  private reconnectTimer: NodeJS.Timeout | undefined;
+  private reconnectAttempt = 0;
+  private readonly activeSessions = new Set<string>();
+  private lastNotificationAt = 0;
+
+  /**
+   * Create a notification service.
+   * @param config - Extension configuration access
+   * @param outputChannel - User-visible log channel
+   * @param dependencies - Test seams and timing overrides
+   */
+  constructor(
+    private readonly config: NotificationConfig,
+    private readonly outputChannel: Logger | undefined,
+    dependencies: NotificationServiceDependencies = {}
+  ) {
+    this.createEventClient =
+      dependencies.createEventClient ??
+      (callbacks => new OpenCodeEventClient(callbacks, { logger: this.outputChannel }));
+    this.reconnectDelayMs = dependencies.reconnectDelayMs ?? DEFAULT_RECONNECT_DELAY_MS;
+    this.maxReconnectDelayMs = dependencies.maxReconnectDelayMs ?? DEFAULT_MAX_RECONNECT_DELAY_MS;
+    this.cooldownMs = dependencies.cooldownMs ?? DEFAULT_IDLE_COOLDOWN_MS;
+    this.now = dependencies.now ?? (() => Date.now());
+    this.eventClient = this.createEventClient({
+      onEvent: event => this.handleEvent(event),
+      onDisconnect: error => this.handleDisconnect(error),
+    });
+  }
+
+  /**
+   * Sync notification listening to the current active runtime port.
+   * @param port - Active runtime port, or undefined when disconnected
+   */
+  public syncConnection(port?: number): void {
+    if (this.activePort === port) {
+      return;
+    }
+
+    const previousPort = this.activePort;
+    this.activePort = port;
+    this.resetStreamState();
+    this.clearReconnectTimer();
+    this.reconnectAttempt = 0;
+    if (previousPort !== undefined) {
+      this.outputChannel?.info(`Stopping OpenCode notification listener on port ${previousPort}`);
+      this.eventClient.stop();
+    }
+
+    if (port !== undefined && this.config.getNotificationsEnabled()) {
+      this.outputChannel?.info(`Starting OpenCode notification listener on port ${port}`);
+      this.eventClient.start(port);
+    }
+  }
+
+  /**
+   * Reload notification behavior after a settings change.
+   */
+  public reloadSettings(): void {
+    this.clearReconnectTimer();
+    this.reconnectAttempt = 0;
+    this.resetStreamState();
+    if (this.activePort !== undefined) {
+      this.outputChannel?.info(
+        `Stopping OpenCode notification listener on port ${this.activePort}`
+      );
+      this.eventClient.stop();
+    }
+
+    if (!this.config.getNotificationsEnabled()) {
+      this.outputChannel?.info('OpenCode notifications disabled; listener remains stopped');
+      return;
+    }
+
+    if (this.activePort !== undefined) {
+      this.outputChannel?.info(
+        `Starting OpenCode notification listener on port ${this.activePort}`
+      );
+      this.eventClient.start(this.activePort);
+    }
+  }
+
+  /**
+   * Dispose notification resources.
+   */
+  public dispose(): void {
+    this.clearReconnectTimer();
+    this.reconnectAttempt = 0;
+    this.resetStreamState();
+    if (this.activePort !== undefined) {
+      this.outputChannel?.info(
+        `Stopping OpenCode notification listener on port ${this.activePort}`
+      );
+    }
+    this.eventClient.stop();
+  }
+
+  private handleEvent(event: { type: string; properties: Record<string, unknown> }): void {
+    if (!this.config.getNotificationsEnabled()) {
+      this.outputChannel?.info(
+        `Ignoring notification event while disabled: ${JSON.stringify({ type: event.type, properties: event.properties })}`
+      );
+      return;
+    }
+
+    if (event.type !== 'session.status') {
+      this.outputChannel?.info(`Ignoring non-session.status event type=${event.type}`);
+      return;
+    }
+
+    // A valid domain event proves the stream recovered, so reset the reconnect
+    // backoff to the base delay for any future disconnect.
+    this.reconnectAttempt = 0;
+
+    const sessionStatusEvent = event as SessionStatusEvent;
+    const status = sessionStatusEvent.properties.status?.type;
+    const sessionID = sessionStatusEvent.properties.sessionID;
+    const sessionKey = sessionID ?? '<unknown>';
+
+    this.outputChannel?.info(
+      `Observed session.status=${status ?? 'unknown'} on port ${this.activePort ?? 'unknown'} for session ${sessionID}`
+    );
+
+    if (!status || status === 'idle') {
+      const sessionWasActive = this.activeSessions.has(sessionKey);
+      if (status === 'idle' && sessionWasActive && this.isOutsideCooldown()) {
+        this.outputChannel?.info(
+          `Notification decision=notify reason=active-to-idle transition session=${sessionID}`
+        );
+        this.lastNotificationAt = this.now();
+        this.activeSessions.delete(sessionKey);
+        void this.showCompletionNotification();
+      } else {
+        this.outputChannel?.info(
+          `Notification decision=ignore reason=${
+            !status
+              ? 'missing-status'
+              : !sessionWasActive
+                ? 'idle-without-prior-active'
+                : 'cooldown-active'
+          } session=${sessionID}`
+        );
+      }
+      return;
+    }
+
+    this.outputChannel?.info(
+      `Notification decision=ignore reason=non-idle-status:${status} session=${sessionID}`
+    );
+    this.activeSessions.add(sessionKey);
+  }
+
+  private handleDisconnect(error?: Error): void {
+    if (error) {
+      this.outputChannel?.warn(`Notification stream disconnected: ${error.message}`);
+    }
+
+    if (!this.config.getNotificationsEnabled() || this.activePort === undefined) {
+      return;
+    }
+
+    this.clearReconnectTimer();
+    this.reconnectAttempt += 1;
+    const delay = Math.min(
+      this.reconnectDelayMs * Math.pow(2, this.reconnectAttempt - 1),
+      this.maxReconnectDelayMs
+    );
+    this.outputChannel?.info(
+      `Scheduling OpenCode notification listener reconnect on port ${this.activePort} in ${delay}ms`
+    );
+    this.reconnectTimer = setTimeout(() => {
+      if (!this.config.getNotificationsEnabled() || this.activePort === undefined) {
+        return;
+      }
+
+      this.outputChannel?.info(
+        `Starting OpenCode notification listener on port ${this.activePort}`
+      );
+      this.eventClient.start(this.activePort);
+    }, delay);
+  }
+
+  private resetStreamState(): void {
+    this.activeSessions.clear();
+    this.lastNotificationAt = 0;
+  }
+
+  private async showCompletionNotification(): Promise<void> {
+    try {
+      await vscode.window.showInformationMessage('OpenCode task complete.');
+    } catch (err) {
+      this.outputChannel?.error(
+        `Failed to show OpenCode completion notification: ${(err as Error).message}`
+      );
+    }
+  }
+
+  private isOutsideCooldown(): boolean {
+    return this.lastNotificationAt === 0 || this.now() - this.lastNotificationAt >= this.cooldownMs;
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = undefined;
+    }
+  }
+}
+
+export default NotificationService;

--- a/src/types.ts
+++ b/src/types.ts
@@ -153,6 +153,25 @@ export interface SSEEvent {
   properties: Record<string, unknown>;
 }
 
+/** Supported OpenCode session status values used by notifications. */
+export type OpenCodeSessionStatus = 'idle' | 'busy' | 'retry' | (string & {});
+
+/** Nested session status payload emitted by OpenCode. */
+export interface OpenCodeSessionStatusPayload {
+  type: OpenCodeSessionStatus;
+  [key: string]: unknown;
+}
+
+/** `session.status` event emitted by OpenCode. */
+export interface SessionStatusEvent extends SSEEvent {
+  type: 'session.status';
+  properties: {
+    sessionID: string;
+    status: OpenCodeSessionStatusPayload;
+    [key: string]: unknown;
+  };
+}
+
 /** POST /session/:id/message request body */
 export interface MessageInput {
   providerID: string;

--- a/test/api/openCodeClient.test.ts
+++ b/test/api/openCodeClient.test.ts
@@ -11,7 +11,7 @@ import {
   OpenCodeServerError,
   OpenCodeUnavailableError,
 } from '../../src/api/errors';
-import { OpenCodeClient } from '../../src/api/openCodeClient';
+import { OpenCodeClient, getEventUrl } from '../../src/api/openCodeClient';
 
 // ---------------------------------------------------------------------------
 // Imports (resolved against mocks above)
@@ -164,6 +164,20 @@ describe('OpenCodeClient', () => {
     it('builds correct base URL', () => {
       const client = createClient({ host: '192.168.1.5', port: 8080 });
       expect(client.getBaseUrl()).toBe('http://192.168.1.5:8080');
+    });
+  });
+
+  // ===========================================================================
+  // getEventUrl
+  // ===========================================================================
+
+  describe('getEventUrl', () => {
+    it('builds the default event URL for the default runtime port', () => {
+      expect(getEventUrl()).toBe('http://127.0.0.1:4096/event');
+    });
+
+    it('builds the event URL for a provided runtime port', () => {
+      expect(getEventUrl(7777)).toBe('http://127.0.0.1:7777/event');
     });
   });
 

--- a/test/api/openCodeEventClient.test.ts
+++ b/test/api/openCodeEventClient.test.ts
@@ -1,0 +1,265 @@
+import {
+  OpenCodeEventClient,
+  type OpenCodeEventStreamConnection,
+  type OpenCodeEventStreamFactory,
+} from '../../src/api/openCodeEventClient';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('OpenCodeEventClient', () => {
+  let onEvent: ReturnType<typeof vi.fn>;
+  let onDisconnect: ReturnType<typeof vi.fn>;
+  let createStream: ReturnType<typeof vi.fn<OpenCodeEventStreamFactory>>;
+  let logger: {
+    info: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  };
+  let streamHandlers:
+    | {
+        onChunk(chunk: string): void;
+        onDisconnect(error?: Error): void;
+      }
+    | undefined;
+  let closeConnection: ReturnType<typeof vi.fn>;
+  let connections: Array<{
+    url: string;
+    handlers: {
+      onChunk(chunk: string): void;
+      onDisconnect(error?: Error): void;
+    };
+    close: ReturnType<typeof vi.fn>;
+  }>;
+
+  beforeEach(() => {
+    onEvent = vi.fn();
+    onDisconnect = vi.fn();
+    logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    closeConnection = vi.fn();
+    streamHandlers = undefined;
+    connections = [];
+    createStream = vi.fn((url, handlers) => {
+      const close = vi.fn();
+      streamHandlers = handlers;
+      closeConnection = close;
+      connections.push({ url, handlers, close });
+      return {
+        close,
+      } satisfies OpenCodeEventStreamConnection;
+    });
+  });
+
+  it('emits the OpenCode domain event type from the JSON payload and ignores malformed frames', () => {
+    const client = new OpenCodeEventClient(
+      { onEvent, onDisconnect },
+      {
+        createStream,
+        logger,
+      }
+    );
+
+    client.start(4200);
+    streamHandlers?.onChunk(
+      'event: message\ndata: {"id":"evt-1","type":"session.status","properties":{"sessionID":"session-1","status":{"type":"busy"}}}\n\n' +
+        'event: message\ndata: not-json\n\n'
+    );
+
+    expect(createStream).toHaveBeenCalledWith(
+      'http://127.0.0.1:4200/event',
+      expect.objectContaining({
+        onChunk: expect.any(Function),
+        onDisconnect: expect.any(Function),
+      })
+    );
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(onEvent).toHaveBeenCalledWith({
+      type: 'session.status',
+      properties: {
+        sessionID: 'session-1',
+        status: { type: 'busy' },
+      },
+    });
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Raw SSE chunk'));
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Raw SSE frame'));
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Parsed OpenCode event'));
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Ignoring malformed SSE frame')
+    );
+    expect(onDisconnect).not.toHaveBeenCalled();
+  });
+
+  it('reassembles chunked SSE frames before emitting the parsed domain event', () => {
+    const client = new OpenCodeEventClient(
+      { onEvent, onDisconnect },
+      {
+        createStream,
+        logger,
+      }
+    );
+
+    client.start(4300);
+    streamHandlers?.onChunk(
+      'event: message\ndata: {"id":"evt-2","type":"session.status","properties":{"sessionID":"session-2","status":{"type":"ret'
+    );
+    streamHandlers?.onChunk('ry"}}}\n\n');
+
+    expect(onEvent).toHaveBeenCalledWith({
+      type: 'session.status',
+      properties: {
+        sessionID: 'session-2',
+        status: { type: 'retry' },
+      },
+    });
+  });
+
+  it('accepts frames without an SSE event line as default message events', () => {
+    const client = new OpenCodeEventClient(
+      { onEvent, onDisconnect },
+      {
+        createStream,
+        logger,
+      }
+    );
+
+    client.start(4301);
+    streamHandlers?.onChunk(
+      'data: {"id":"evt-3","type":"session.status","properties":{"sessionID":"session-3","status":{"type":"busy"}}}\n\n'
+    );
+
+    expect(onEvent).toHaveBeenCalledWith({
+      type: 'session.status',
+      properties: {
+        sessionID: 'session-3',
+        status: { type: 'busy' },
+      },
+    });
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('defaulting to SSE event "message"')
+    );
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('"sseEvent":"message"'));
+    expect(logger.warn.mock.calls.flat().join('\n')).not.toContain('without event line');
+  });
+
+  it('parses multi-line data-only frames using the JSON domain type', () => {
+    const client = new OpenCodeEventClient(
+      { onEvent, onDisconnect },
+      {
+        createStream,
+        logger,
+      }
+    );
+
+    client.start(4302);
+    streamHandlers?.onChunk(
+      'data: {"id":"evt-4",\ndata: "type":"session.status","properties":{"sessionID":"session-4","status":{"type":"idle"}}}\n\n'
+    );
+
+    expect(onEvent).toHaveBeenCalledWith({
+      type: 'session.status',
+      properties: {
+        sessionID: 'session-4',
+        status: { type: 'idle' },
+      },
+    });
+  });
+
+  it('ignores a late disconnect from a previous connection after a new start', () => {
+    const client = new OpenCodeEventClient(
+      { onEvent, onDisconnect },
+      {
+        createStream,
+        logger,
+      }
+    );
+
+    client.start(4600);
+    const firstConnection = connections[0];
+
+    client.start(4601);
+    const secondConnection = connections[1];
+
+    // A late/asynchronous disconnect from the OLD connection (e.g. ECONNRESET
+    // after request.destroy()) must be ignored: it must neither trigger a
+    // reconnect nor detach the current connection.
+    firstConnection.handlers.onDisconnect(new Error('ECONNRESET'));
+
+    expect(onDisconnect).not.toHaveBeenCalled();
+
+    // The new connection is still the active one, so stop() closes it.
+    client.stop();
+    expect(secondConnection.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('parses frames separated by CRLF boundaries across a split chunk', () => {
+    const client = new OpenCodeEventClient(
+      { onEvent, onDisconnect },
+      {
+        createStream,
+        logger,
+      }
+    );
+
+    client.start(4700);
+
+    // First frame plus the start of the second, split in the middle of a \r\n
+    // sequence (chunk 1 ends with "\r", chunk 2 begins with "\n").
+    streamHandlers?.onChunk(
+      'event: message\r\ndata: {"id":"evt-1","type":"session.status","properties":{"sessionID":"session-1","status":{"type":"busy"}}}\r\n\r'
+    );
+    streamHandlers?.onChunk(
+      '\nevent: message\r\ndata: {"id":"evt-2","type":"session.status","properties":{"sessionID":"session-2","status":{"type":"idle"}}}\r\n\r\n'
+    );
+
+    expect(onEvent).toHaveBeenNthCalledWith(1, {
+      type: 'session.status',
+      properties: {
+        sessionID: 'session-1',
+        status: { type: 'busy' },
+      },
+    });
+    expect(onEvent).toHaveBeenNthCalledWith(2, {
+      type: 'session.status',
+      properties: {
+        sessionID: 'session-2',
+        status: { type: 'idle' },
+      },
+    });
+  });
+
+  it('does not report a disconnect when the client is stopped locally', () => {
+    const client = new OpenCodeEventClient(
+      { onEvent, onDisconnect },
+      {
+        createStream,
+        logger,
+      }
+    );
+
+    client.start(4400);
+    client.stop();
+    streamHandlers?.onDisconnect(new Error('socket closed'));
+
+    expect(closeConnection).toHaveBeenCalledTimes(1);
+    expect(onDisconnect).not.toHaveBeenCalled();
+  });
+
+  it('reports disconnect callbacks for remote stream failures', () => {
+    const client = new OpenCodeEventClient(
+      { onEvent, onDisconnect },
+      {
+        createStream,
+        logger,
+      }
+    );
+
+    client.start(4500);
+    const error = new Error('stream dropped');
+    streamHandlers?.onDisconnect(error);
+
+    expect(onDisconnect).toHaveBeenCalledWith(error);
+  });
+});

--- a/test/commands/openNewInstance.test.ts
+++ b/test/commands/openNewInstance.test.ts
@@ -1,0 +1,94 @@
+import { openOpencodeForWorkspace } from '../../src/commands/openNewInstance';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('vscode', () => ({
+  window: {
+    withProgress: vi.fn(async (_options: unknown, task: (progress: unknown) => Promise<void>) =>
+      task({ report: vi.fn() })
+    ),
+    setStatusBarMessage: vi.fn(),
+    showErrorMessage: vi.fn(),
+  },
+  ProgressLocation: { Notification: 15 },
+}));
+
+function createDeps() {
+  const connectionService = {
+    findPortForWorkspace: vi.fn(async () => undefined as number | undefined),
+    connectToKnownPort: vi.fn(async () => true),
+  };
+  const instanceManager = {
+    getTerminalForPort: vi.fn(() => undefined as { show: (b: boolean) => void } | undefined),
+    spawnInTerminal: vi.fn(async () => undefined),
+    findAvailablePort: vi.fn(async () => 5005),
+  };
+  const outputChannel = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+  return { connectionService, instanceManager, outputChannel };
+}
+
+describe('openOpencodeForWorkspace notification/connection wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('attaches to a freshly spawned instance on its known port', async () => {
+    const { connectionService, instanceManager, outputChannel } = createDeps();
+    connectionService.findPortForWorkspace.mockResolvedValueOnce(undefined);
+    instanceManager.findAvailablePort.mockResolvedValueOnce(5005);
+
+    await openOpencodeForWorkspace(
+      '/workspace/app',
+      connectionService as never,
+      instanceManager as never,
+      outputChannel as never
+    );
+
+    expect(instanceManager.spawnInTerminal).toHaveBeenCalledWith(5005, {
+      cwd: '/workspace/app',
+      asEditor: true,
+    });
+    expect(connectionService.connectToKnownPort).toHaveBeenCalledWith(5005);
+  });
+
+  it('attaches to an existing instance with a tracked terminal (no re-spawn)', async () => {
+    const { connectionService, instanceManager, outputChannel } = createDeps();
+    connectionService.findPortForWorkspace.mockResolvedValueOnce(4096);
+    const show = vi.fn();
+    instanceManager.getTerminalForPort.mockReturnValueOnce({ show });
+
+    await openOpencodeForWorkspace(
+      '/workspace/app',
+      connectionService as never,
+      instanceManager as never,
+      outputChannel as never
+    );
+
+    expect(show).toHaveBeenCalledWith(false);
+    expect(instanceManager.spawnInTerminal).not.toHaveBeenCalled();
+    expect(connectionService.connectToKnownPort).toHaveBeenCalledWith(4096);
+  });
+
+  it('attaches to an existing port without a tracked terminal after opening a tab', async () => {
+    const { connectionService, instanceManager, outputChannel } = createDeps();
+    connectionService.findPortForWorkspace.mockResolvedValueOnce(4096);
+    instanceManager.getTerminalForPort.mockReturnValueOnce(undefined);
+
+    await openOpencodeForWorkspace(
+      '/workspace/app',
+      connectionService as never,
+      instanceManager as never,
+      outputChannel as never
+    );
+
+    expect(instanceManager.spawnInTerminal).toHaveBeenCalledWith(4096, {
+      cwd: '/workspace/app',
+      asEditor: true,
+    });
+    expect(connectionService.connectToKnownPort).toHaveBeenCalledWith(4096);
+  });
+});

--- a/test/commands/toggleNotifications.test.ts
+++ b/test/commands/toggleNotifications.test.ts
@@ -1,0 +1,62 @@
+import { handleToggleNotifications } from '../../src/commands/toggleNotifications';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('vscode', () => ({
+  window: {
+    showInformationMessage: vi.fn(async () => undefined),
+    showErrorMessage: vi.fn(async () => undefined),
+  },
+}));
+
+describe('handleToggleNotifications', () => {
+  let configManager: {
+    getNotificationsEnabled: ReturnType<typeof vi.fn>;
+    setNotificationsEnabled: ReturnType<typeof vi.fn>;
+  };
+  let outputChannel: {
+    info: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    configManager = {
+      getNotificationsEnabled: vi.fn(() => true),
+      setNotificationsEnabled: vi.fn(async () => undefined),
+    };
+    outputChannel = {
+      info: vi.fn(),
+      error: vi.fn(),
+    };
+  });
+
+  it('disables notifications and confirms the new state', async () => {
+    const { window } = await import('vscode');
+
+    await handleToggleNotifications(configManager as never, outputChannel as never);
+
+    expect(configManager.setNotificationsEnabled).toHaveBeenCalledWith(false);
+    expect(window.showInformationMessage).toHaveBeenCalledWith('OpenCode notifications disabled.');
+  });
+
+  it('enables notifications when they were previously disabled', async () => {
+    const { window } = await import('vscode');
+    configManager.getNotificationsEnabled.mockReturnValue(false);
+
+    await handleToggleNotifications(configManager as never, outputChannel as never);
+
+    expect(configManager.setNotificationsEnabled).toHaveBeenCalledWith(true);
+    expect(window.showInformationMessage).toHaveBeenCalledWith('OpenCode notifications enabled.');
+  });
+
+  it('surfaces configuration update failures', async () => {
+    const { window } = await import('vscode');
+    configManager.setNotificationsEnabled.mockRejectedValueOnce(new Error('boom'));
+
+    await handleToggleNotifications(configManager as never, outputChannel as never);
+
+    expect(outputChannel.error).toHaveBeenCalledWith('Failed to toggle notifications: boom');
+    expect(window.showErrorMessage).toHaveBeenCalledWith('Failed to toggle notifications: boom');
+  });
+});

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,0 +1,40 @@
+import { ConfigManager } from '../src/config';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const get = vi.fn();
+const update = vi.fn(async () => undefined);
+
+vi.mock('vscode', () => ({
+  workspace: {
+    getConfiguration: vi.fn(() => ({
+      get,
+      update,
+    })),
+  },
+  ConfigurationTarget: {
+    Global: 'global',
+  },
+}));
+
+describe('ConfigManager notifications setting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns true by default when notificationsEnabled is unset', () => {
+    get.mockReturnValueOnce(undefined);
+
+    const configManager = ConfigManager.getInstance({} as never);
+
+    expect(configManager.getNotificationsEnabled()).toBe(true);
+  });
+
+  it('persists notificationsEnabled updates globally', async () => {
+    const configManager = ConfigManager.getInstance({} as never);
+
+    await configManager.setNotificationsEnabled(false);
+
+    expect(update).toHaveBeenCalledWith('notificationsEnabled', false, 'global');
+  });
+});

--- a/test/connection/connectionService.test.ts
+++ b/test/connection/connectionService.test.ts
@@ -1,0 +1,264 @@
+import { ConnectionService } from '../../src/connection/connectionService';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type ConnectionEvent = { connected: boolean; port?: number };
+
+function getConnectionTestState(): {
+  listeners: Set<(event: ConnectionEvent) => void>;
+  defaultPort?: number;
+  defaultIsValid?: boolean;
+  clearDefault: ReturnType<typeof vi.fn>;
+  clientBehaviors: Map<number, { testConnection?: boolean; getPath?: { directory: string } }>;
+  createdClients: Array<{ port: number; destroyed: boolean }>;
+} {
+  const globalState = globalThis as unknown as {
+    __connectionTestState?: {
+      listeners: Set<(event: ConnectionEvent) => void>;
+      defaultPort?: number;
+      defaultIsValid?: boolean;
+      clearDefault: ReturnType<typeof vi.fn>;
+      clientBehaviors: Map<number, { testConnection?: boolean; getPath?: { directory: string } }>;
+      createdClients: Array<{ port: number; destroyed: boolean }>;
+    };
+  };
+
+  if (!globalState.__connectionTestState) {
+    globalState.__connectionTestState = {
+      listeners: new Set<(event: ConnectionEvent) => void>(),
+      defaultPort: undefined,
+      defaultIsValid: false,
+      clearDefault: vi.fn(),
+      clientBehaviors: new Map<
+        number,
+        { testConnection?: boolean; getPath?: { directory: string } }
+      >(),
+      createdClients: [],
+    };
+  }
+
+  return globalState.__connectionTestState;
+}
+
+vi.mock('vscode', () => {
+  const state = getConnectionTestState();
+
+  return {
+    workspace: {
+      workspaceFolders: [{ uri: { fsPath: '/workspace/app' } }],
+    },
+    env: {
+      remoteName: undefined,
+    },
+    EventEmitter: vi.fn(() => ({
+      event: (listener: (event: ConnectionEvent) => void) => {
+        state.listeners.add(listener);
+        return {
+          dispose: () => state.listeners.delete(listener),
+        };
+      },
+      fire: (event: ConnectionEvent) => {
+        for (const listener of state.listeners) {
+          listener(event);
+        }
+      },
+      dispose: vi.fn(),
+    })),
+  };
+});
+
+vi.mock('../../src/instance/defaultInstanceManager', () => {
+  const state = getConnectionTestState();
+
+  state.clearDefault.mockImplementation(() => {
+    state.defaultPort = undefined;
+  });
+
+  return {
+    DefaultInstanceManager: {
+      getInstance: () => ({
+        getDefaultPort: () => state.defaultPort,
+        isValid: vi.fn(async () => state.defaultIsValid ?? false),
+        clearDefault: state.clearDefault,
+      }),
+    },
+  };
+});
+
+vi.mock('../../src/api/openCodeClient', () => {
+  const state = getConnectionTestState();
+
+  return {
+    OpenCodeClient: class MockOpenCodeClient {
+      public readonly port: number;
+      public destroyed = false;
+
+      constructor(config?: { port?: number }) {
+        this.port = config?.port ?? 4096;
+        state.createdClients?.push(this);
+      }
+
+      public async getPath(): Promise<{ directory: string }> {
+        return (
+          state.clientBehaviors?.get(this.port)?.getPath ?? { directory: `/runtime/${this.port}` }
+        );
+      }
+
+      public async testConnection(): Promise<boolean> {
+        return state.clientBehaviors?.get(this.port)?.testConnection ?? false;
+      }
+
+      public getPort(): number {
+        return this.port;
+      }
+
+      public destroy(): void {
+        this.destroyed = true;
+      }
+    },
+  };
+});
+
+describe('ConnectionService', () => {
+  const mockState = getConnectionTestState();
+
+  const outputChannel = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+
+  const configManager = {
+    getPort: vi.fn(() => 4096),
+  };
+
+  const instanceManager = {
+    scanForProcesses: vi.fn(async () => []),
+    findAvailablePort: vi.fn(async () => 5001),
+    spawnInTerminal: vi.fn(async () => undefined),
+    getRunningInstance: vi.fn(async () => ({ isRunning: false })),
+    spawnInstance: vi.fn(async () => ({ success: true })),
+    focusTerminal: vi.fn(async () => true),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState.listeners.clear();
+    mockState.defaultPort = undefined;
+    mockState.defaultIsValid = false;
+    mockState.clientBehaviors.clear();
+    mockState.createdClients.length = 0;
+  });
+
+  it('emits a connection event when discoverAndConnect switches to a new active port', async () => {
+    instanceManager.scanForProcesses.mockResolvedValueOnce([{ pid: 1, port: 4100 }]);
+    mockState.clientBehaviors.set(4100, {
+      getPath: { directory: '/workspace/app' },
+    });
+
+    const service = new ConnectionService(
+      configManager as never,
+      instanceManager as never,
+      outputChannel
+    );
+    const listener = vi.fn();
+    service.onDidChangeConnectionState(listener);
+
+    await service.discoverAndConnect(1, 0);
+
+    expect(listener).toHaveBeenCalledWith({ connected: true, port: 4100 });
+    expect(service.getPort()).toBe(4100);
+  });
+
+  it('emits a disconnect event before reconnecting when the active port no longer matches the workspace', async () => {
+    mockState.defaultPort = 4096;
+    mockState.defaultIsValid = true;
+    mockState.clientBehaviors.set(4096, {
+      getPath: { directory: '/workspace/app' },
+    });
+    mockState.clientBehaviors.set(4200, {
+      getPath: { directory: '/workspace/app' },
+    });
+    instanceManager.scanForProcesses.mockResolvedValueOnce([{ pid: 2, port: 4200 }]);
+
+    const service = new ConnectionService(
+      configManager as never,
+      instanceManager as never,
+      outputChannel
+    );
+    const listener = vi.fn();
+    service.onDidChangeConnectionState(listener);
+
+    await service.ensureConnected();
+
+    mockState.clientBehaviors.set(4096, {
+      testConnection: true,
+      getPath: { directory: '/other/workspace' },
+    });
+
+    await service.ensureConnected();
+
+    expect(listener.mock.calls).toContainEqual([{ connected: false }]);
+    expect(listener.mock.calls).toContainEqual([{ connected: true, port: 4200 }]);
+  });
+
+  it('attaches to a known port and emits the connected state without scanning processes', async () => {
+    const service = new ConnectionService(
+      configManager as never,
+      instanceManager as never,
+      outputChannel
+    );
+    const listener = vi.fn();
+    service.onDidChangeConnectionState(listener);
+
+    const attached = await service.connectToKnownPort(4300);
+
+    expect(attached).toBe(true);
+    expect(service.getPort()).toBe(4300);
+    expect(listener).toHaveBeenCalledWith({ connected: true, port: 4300 });
+    // connectToKnownPort must not rely on discovery/auto-spawn.
+    expect(instanceManager.scanForProcesses).not.toHaveBeenCalled();
+    expect(instanceManager.findAvailablePort).not.toHaveBeenCalled();
+  });
+
+  it('re-emits the connected state when already attached to the same known port', async () => {
+    const service = new ConnectionService(
+      configManager as never,
+      instanceManager as never,
+      outputChannel
+    );
+    await service.connectToKnownPort(4300);
+
+    const listener = vi.fn();
+    service.onDidChangeConnectionState(listener);
+    const attached = await service.connectToKnownPort(4300);
+
+    expect(attached).toBe(true);
+    expect(service.getPort()).toBe(4300);
+    expect(listener).toHaveBeenCalledWith({ connected: true, port: 4300 });
+  });
+
+  it('emits the connected state exactly once when falling back to the configured port', async () => {
+    // Discovery finds a non-matching process (breaks quickly without waits),
+    // auto-spawn fails, then the configured-port fallback connects.
+    instanceManager.scanForProcesses.mockResolvedValueOnce([{ pid: 9, port: 9999 }]);
+    instanceManager.findAvailablePort.mockRejectedValueOnce(new Error('no port'));
+    mockState.clientBehaviors.set(4096, { testConnection: true });
+
+    const service = new ConnectionService(
+      configManager as never,
+      instanceManager as never,
+      outputChannel
+    );
+    const listener = vi.fn();
+    service.onDidChangeConnectionState(listener);
+
+    const connected = await service.ensureConnected();
+
+    expect(connected).toBe(true);
+    expect(service.getPort()).toBe(4096);
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith({ connected: true, port: 4096 });
+  });
+});

--- a/test/extension/notificationWiring.test.ts
+++ b/test/extension/notificationWiring.test.ts
@@ -1,0 +1,256 @@
+import { activate, deactivate } from '../../src/extension';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const extensionState = {
+  connectionService: {
+    onDidChangeConnectionState: vi.fn(),
+    discoverAndConnect: vi.fn(async () => false),
+    getPort: vi.fn(() => undefined),
+    getClient: vi.fn(() => undefined),
+  },
+  configManager: {
+    getNotificationsEnabled: vi.fn(() => true),
+    setNotificationsEnabled: vi.fn(async () => undefined),
+  },
+  outputChannel: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    dispose: vi.fn(),
+  },
+  connectionHandler: undefined as
+    | ((event: { connected: boolean; port?: number }) => void)
+    | undefined,
+  configurationHandler: undefined as
+    | ((event: { affectsConfiguration(section: string): boolean }) => void)
+    | undefined,
+  eventCallbacks: undefined as
+    | {
+        onEvent(event: { type: string; properties: Record<string, unknown> }): void;
+        onDisconnect(error?: Error): void;
+      }
+    | undefined,
+  eventClientStart: vi.fn(),
+  eventClientStop: vi.fn(),
+};
+
+vi.mock('vscode', () => ({
+  window: {
+    createOutputChannel: vi.fn(() => extensionState.outputChannel),
+    showInformationMessage: vi.fn(async () => undefined),
+  },
+  workspace: {
+    onDidChangeConfiguration: vi.fn(handler => {
+      extensionState.configurationHandler = handler;
+      return { dispose: vi.fn() };
+    }),
+    onDidChangeWorkspaceFolders: vi.fn(() => ({ dispose: vi.fn() })),
+  },
+  languages: {
+    registerCodeActionsProvider: vi.fn(() => ({ dispose: vi.fn() })),
+  },
+  commands: {
+    registerCommand: vi.fn(() => ({ dispose: vi.fn() })),
+  },
+  env: {
+    remoteName: undefined,
+  },
+  CodeActionKind: {
+    QuickFix: {},
+  },
+}));
+
+vi.mock('../../src/notifications/notificationService', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../src/notifications/notificationService')
+  >('../../src/notifications/notificationService');
+
+  return {
+    ...actual,
+    NotificationService: vi.fn((configManager, outputChannel) => {
+      return new actual.NotificationService(configManager, outputChannel, {
+        createEventClient: callbacks => {
+          extensionState.eventCallbacks = callbacks;
+
+          return {
+            start: extensionState.eventClientStart,
+            stop: extensionState.eventClientStop,
+          };
+        },
+      });
+    }),
+  };
+});
+
+vi.mock('../../src/connection/connectionService', () => ({
+  ConnectionService: vi.fn(() => ({
+    ...extensionState.connectionService,
+    onDidChangeConnectionState: vi.fn(handler => {
+      extensionState.connectionHandler = handler;
+      return { dispose: vi.fn() };
+    }),
+  })),
+  isRemoteSession: vi.fn(() => false),
+}));
+
+vi.mock('../../src/config', () => ({
+  ConfigManager: {
+    getInstance: vi.fn(() => extensionState.configManager),
+  },
+}));
+
+vi.mock('../../src/instance/instanceManager', () => ({
+  InstanceManager: {
+    getInstance: vi.fn(() => ({
+      setLogger: vi.fn(),
+    })),
+    resetInstance: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/statusBar', () => ({
+  StatusBarManager: {
+    getInstance: vi.fn(() => ({
+      initialize: vi.fn(),
+      updateConnectionStatus: vi.fn(),
+    })),
+  },
+}));
+
+vi.mock('../../src/providers/codeActionProvider', () => ({
+  OpenCodeCodeActionProvider: vi.fn(),
+}));
+
+vi.mock('../../src/instance/defaultInstanceManager', () => ({
+  DefaultInstanceManager: {
+    getInstance: vi.fn(() => ({
+      clearDefault: vi.fn(),
+    })),
+  },
+}));
+
+vi.mock('../../src/commands', () => ({
+  handleAddMultipleFiles: vi.fn(),
+  handleAddSelectionToPrompt: vi.fn(),
+  handleAddToPrompt: vi.fn(),
+  handleCheckInstance: vi.fn(),
+  handleOpenInOpencode: vi.fn(),
+  handleOpenNewInstance: vi.fn(),
+  handleSelectDefaultInstance: vi.fn(),
+  handleSendDebugContext: vi.fn(),
+  handleSendPath: vi.fn(),
+  handleSendRelativePath: vi.fn(),
+  handleShowWorkspace: vi.fn(),
+  handleToggleNotifications: vi.fn(),
+  showStatusBarMenu: vi.fn(),
+}));
+
+describe('notification wiring in extension', () => {
+  const createSessionStatusEvent = (status: string) => ({
+    type: 'session.status',
+    properties: {
+      sessionID: 'session-1',
+      status: { type: status },
+    },
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    extensionState.connectionHandler = undefined;
+    extensionState.configurationHandler = undefined;
+    extensionState.eventCallbacks = undefined;
+    extensionState.eventClientStart.mockReset();
+    extensionState.eventClientStop.mockReset();
+    extensionState.configManager.getNotificationsEnabled.mockReturnValue(true);
+  });
+
+  it('enables notification behavior only after configuration is turned on', async () => {
+    const { window } = await import('vscode');
+    extensionState.configManager.getNotificationsEnabled.mockReturnValue(false);
+
+    activate({} as never, { subscriptions: [] } as never);
+    extensionState.connectionHandler?.({ connected: true, port: 4300 });
+    extensionState.eventCallbacks?.onEvent(createSessionStatusEvent('working'));
+    extensionState.eventCallbacks?.onEvent(createSessionStatusEvent('idle'));
+
+    expect(window.showInformationMessage).not.toHaveBeenCalled();
+
+    extensionState.configManager.getNotificationsEnabled.mockReturnValue(true);
+    extensionState.configurationHandler?.({
+      affectsConfiguration: section =>
+        section === 'opencode' || section === 'opencode.notificationsEnabled',
+    });
+    extensionState.eventCallbacks?.onEvent(createSessionStatusEvent('working'));
+    extensionState.eventCallbacks?.onEvent(createSessionStatusEvent('idle'));
+
+    expect(extensionState.eventClientStop).toHaveBeenCalledTimes(1);
+    expect(extensionState.eventClientStart).toHaveBeenCalledOnce();
+    expect(extensionState.eventClientStart).toHaveBeenCalledWith(4300);
+    expect(window.showInformationMessage).toHaveBeenCalledWith('OpenCode task complete.');
+  });
+
+  it('follows runtime port changes and ignores stale activity from the previous active connection', async () => {
+    const { window } = await import('vscode');
+
+    activate({} as never, { subscriptions: [] } as never);
+
+    extensionState.connectionHandler?.({ connected: true, port: 4300 });
+    extensionState.eventCallbacks?.onEvent(createSessionStatusEvent('working'));
+    extensionState.connectionHandler?.({ connected: true, port: 4301 });
+    extensionState.eventCallbacks?.onEvent(createSessionStatusEvent('idle'));
+
+    expect(window.showInformationMessage).not.toHaveBeenCalled();
+
+    extensionState.eventCallbacks?.onEvent(createSessionStatusEvent('working'));
+    extensionState.eventCallbacks?.onEvent(createSessionStatusEvent('idle'));
+
+    expect(extensionState.eventClientStart).toHaveBeenNthCalledWith(1, 4300);
+    expect(extensionState.eventClientStart).toHaveBeenNthCalledWith(2, 4301);
+    expect(window.showInformationMessage).toHaveBeenCalledWith('OpenCode task complete.');
+  });
+
+  it('reloads notifications when the notificationsEnabled setting changes', () => {
+    activate({} as never, { subscriptions: [] } as never);
+    extensionState.connectionHandler?.({ connected: true, port: 4300 });
+
+    extensionState.configurationHandler?.({
+      affectsConfiguration: section =>
+        section === 'opencode' || section === 'opencode.notificationsEnabled',
+    });
+
+    expect(extensionState.eventClientStop).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reset the notification stream for unrelated opencode configuration changes', async () => {
+    const { window } = await import('vscode');
+
+    activate({} as never, { subscriptions: [] } as never);
+    extensionState.connectionHandler?.({ connected: true, port: 4300 });
+    extensionState.eventCallbacks?.onEvent(createSessionStatusEvent('working'));
+
+    // An unrelated setting (e.g. opencode.port) still logs but must not reload
+    // the notification listener, which would reset in-flight stream state.
+    extensionState.configurationHandler?.({
+      affectsConfiguration: section => section === 'opencode' || section === 'opencode.port',
+    });
+
+    expect(extensionState.eventClientStop).not.toHaveBeenCalled();
+
+    extensionState.eventCallbacks?.onEvent(createSessionStatusEvent('idle'));
+
+    expect(window.showInformationMessage).toHaveBeenCalledWith('OpenCode task complete.');
+  });
+
+  it('syncs notifications with connection-state changes and disposes on deactivate', () => {
+    activate({} as never, { subscriptions: [] } as never);
+
+    extensionState.connectionHandler?.({ connected: true, port: 4300 });
+    extensionState.connectionHandler?.({ connected: false });
+    deactivate();
+
+    expect(extensionState.eventClientStart).toHaveBeenNthCalledWith(1, 4300);
+    expect(extensionState.eventClientStop).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test/notifications/notificationService.test.ts
+++ b/test/notifications/notificationService.test.ts
@@ -1,0 +1,442 @@
+import { NotificationService } from '../../src/notifications/notificationService';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('vscode', () => ({
+  window: {
+    showInformationMessage: vi.fn(async () => undefined),
+  },
+}));
+
+describe('NotificationService', () => {
+  let showInformationMessage: ReturnType<typeof vi.fn>;
+  let outputChannel: {
+    info: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  };
+  let createEventClient: ReturnType<typeof vi.fn>;
+  let clientCallbacks:
+    | {
+        onEvent(event: { type: string; properties: Record<string, unknown> }): void;
+        onDisconnect(error?: Error): void;
+      }
+    | undefined;
+  let start: ReturnType<typeof vi.fn>;
+  let stop: ReturnType<typeof vi.fn>;
+  let getNotificationsEnabled: ReturnType<typeof vi.fn>;
+
+  const createSessionStatusEvent = (status: string) => ({
+    type: 'session.status',
+    properties: {
+      sessionID: 'session-1',
+      status: { type: status },
+    },
+  });
+
+  const createStatusEvent = (status: string, sessionID: string) => ({
+    type: 'session.status',
+    properties: {
+      sessionID,
+      status: { type: status },
+    },
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-08T13:00:00Z'));
+    ({
+      window: { showInformationMessage },
+    } = await import('vscode'));
+    outputChannel = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    start = vi.fn();
+    stop = vi.fn();
+    clientCallbacks = undefined;
+    createEventClient = vi.fn(callbacks => {
+      clientCallbacks = callbacks;
+      return {
+        start,
+        stop,
+      };
+    });
+    getNotificationsEnabled = vi.fn(() => true);
+  });
+
+  it('notifies once for a non-idle to idle transition and suppresses repeated idle events', async () => {
+    const service = new NotificationService(
+      {
+        getNotificationsEnabled,
+      },
+      outputChannel,
+      {
+        createEventClient,
+      }
+    );
+
+    service.syncConnection(4100);
+    clientCallbacks?.onEvent(createSessionStatusEvent('working'));
+    clientCallbacks?.onEvent(createSessionStatusEvent('idle'));
+    clientCallbacks?.onEvent(createSessionStatusEvent('idle'));
+
+    expect(start).toHaveBeenCalledWith(4100);
+    expect(showInformationMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('starts listening and notifies when enabled by configuration', async () => {
+    const service = new NotificationService(
+      {
+        getNotificationsEnabled,
+      },
+      outputChannel,
+      {
+        createEventClient,
+      }
+    );
+
+    service.syncConnection(4101);
+    clientCallbacks?.onEvent(createSessionStatusEvent('working'));
+    clientCallbacks?.onEvent(createSessionStatusEvent('idle'));
+
+    expect(start).toHaveBeenCalledOnce();
+    expect(start).toHaveBeenCalledWith(4101);
+    expect(outputChannel.info).toHaveBeenCalledWith(
+      expect.stringContaining('Starting OpenCode notification listener on port 4101')
+    );
+    expect(outputChannel.info).toHaveBeenCalledWith(
+      expect.stringContaining('Observed session.status=working')
+    );
+    expect(outputChannel.info).toHaveBeenCalledWith(
+      expect.stringContaining('Observed session.status=idle')
+    );
+    expect(outputChannel.info).toHaveBeenCalledWith(
+      expect.stringContaining('Notification decision=notify')
+    );
+    expect(showInformationMessage).toHaveBeenCalledWith('OpenCode task complete.');
+  });
+
+  it('does not notify when idle arrives without prior work', async () => {
+    const service = new NotificationService(
+      {
+        getNotificationsEnabled,
+      },
+      outputChannel,
+      {
+        createEventClient,
+      }
+    );
+
+    service.syncConnection(4100);
+    clientCallbacks?.onEvent(createSessionStatusEvent('idle'));
+
+    expect(outputChannel.info).toHaveBeenCalledWith(
+      expect.stringContaining('Notification decision=ignore')
+    );
+    expect(showInformationMessage).not.toHaveBeenCalled();
+  });
+
+  it('logs listener stop and ignored non-session events without changing behavior', async () => {
+    const service = new NotificationService(
+      {
+        getNotificationsEnabled,
+      },
+      outputChannel,
+      {
+        createEventClient,
+      }
+    );
+
+    service.syncConnection(4202);
+    clientCallbacks?.onEvent({
+      type: 'session.created',
+      properties: {
+        sessionID: 'session-1',
+      },
+    });
+    service.syncConnection(undefined);
+
+    expect(outputChannel.info).toHaveBeenCalledWith(
+      expect.stringContaining('Ignoring non-session.status event type=session.created')
+    );
+    expect(outputChannel.info).toHaveBeenCalledWith(
+      expect.stringContaining('Stopping OpenCode notification listener on port 4202')
+    );
+    expect(showInformationMessage).not.toHaveBeenCalled();
+  });
+
+  it('does not start listening when disabled by configuration', async () => {
+    getNotificationsEnabled.mockReturnValue(false);
+
+    const service = new NotificationService(
+      {
+        getNotificationsEnabled,
+      },
+      outputChannel,
+      {
+        createEventClient,
+      }
+    );
+
+    service.syncConnection(4200);
+
+    expect(start).not.toHaveBeenCalled();
+    expect(showInformationMessage).not.toHaveBeenCalled();
+  });
+
+  it('stops listening when disabled and resumes on the active port when re-enabled', async () => {
+    const service = new NotificationService(
+      {
+        getNotificationsEnabled,
+      },
+      outputChannel,
+      {
+        createEventClient,
+      }
+    );
+
+    service.syncConnection(4200);
+    getNotificationsEnabled.mockReturnValue(false);
+    service.reloadSettings();
+    getNotificationsEnabled.mockReturnValue(true);
+    service.reloadSettings();
+
+    expect(stop).toHaveBeenCalledTimes(2);
+    expect(start).toHaveBeenNthCalledWith(1, 4200);
+    expect(start).toHaveBeenNthCalledWith(2, 4200);
+  });
+
+  it('stops listening when disabled and ignores stale idle events until re-enabled', async () => {
+    const service = new NotificationService(
+      {
+        getNotificationsEnabled,
+      },
+      outputChannel,
+      {
+        createEventClient,
+      }
+    );
+
+    service.syncConnection(4201);
+    clientCallbacks?.onEvent(createSessionStatusEvent('working'));
+
+    getNotificationsEnabled.mockReturnValue(false);
+    service.reloadSettings();
+    clientCallbacks?.onEvent(createSessionStatusEvent('idle'));
+
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(showInformationMessage).not.toHaveBeenCalled();
+
+    getNotificationsEnabled.mockReturnValue(true);
+    service.reloadSettings();
+    clientCallbacks?.onEvent(createSessionStatusEvent('working'));
+    clientCallbacks?.onEvent(createSessionStatusEvent('idle'));
+
+    expect(start).toHaveBeenNthCalledWith(1, 4201);
+    expect(start).toHaveBeenNthCalledWith(2, 4201);
+    expect(showInformationMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('switches the listener to the new active runtime port', async () => {
+    const service = new NotificationService(
+      {
+        getNotificationsEnabled,
+      },
+      outputChannel,
+      {
+        createEventClient,
+      }
+    );
+
+    service.syncConnection(4300);
+    service.syncConnection(4301);
+
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(start).toHaveBeenNthCalledWith(1, 4300);
+    expect(start).toHaveBeenNthCalledWith(2, 4301);
+  });
+
+  it('ignores activity from a previous active port after switching to a new runtime port', async () => {
+    const service = new NotificationService(
+      {
+        getNotificationsEnabled,
+      },
+      outputChannel,
+      {
+        createEventClient,
+      }
+    );
+
+    service.syncConnection(4300);
+    clientCallbacks?.onEvent(createSessionStatusEvent('working'));
+
+    service.syncConnection(4301);
+    clientCallbacks?.onEvent(createSessionStatusEvent('idle'));
+
+    expect(showInformationMessage).not.toHaveBeenCalled();
+
+    clientCallbacks?.onEvent(createSessionStatusEvent('working'));
+    clientCallbacks?.onEvent(createSessionStatusEvent('idle'));
+
+    expect(showInformationMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('reconnects after a disconnect while notifications remain enabled', async () => {
+    const service = new NotificationService(
+      {
+        getNotificationsEnabled,
+      },
+      outputChannel,
+      {
+        createEventClient,
+        reconnectDelayMs: 500,
+      }
+    );
+
+    service.syncConnection(4400);
+    clientCallbacks?.onDisconnect(new Error('socket dropped'));
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(start).toHaveBeenNthCalledWith(1, 4400);
+    expect(start).toHaveBeenNthCalledWith(2, 4400);
+  });
+
+  it('backs off reconnect delays across consecutive disconnects', async () => {
+    const service = new NotificationService(
+      {
+        getNotificationsEnabled,
+      },
+      outputChannel,
+      {
+        createEventClient,
+        reconnectDelayMs: 100,
+        maxReconnectDelayMs: 400,
+      }
+    );
+
+    service.syncConnection(4500);
+    clientCallbacks?.onDisconnect(new Error('first drop'));
+    await vi.advanceTimersByTimeAsync(100);
+    clientCallbacks?.onDisconnect(new Error('second drop'));
+    await vi.advanceTimersByTimeAsync(199);
+
+    expect(start).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(start).toHaveBeenCalledTimes(3);
+    expect(start).toHaveBeenNthCalledWith(3, 4500);
+  });
+
+  it('tracks busy-to-idle transitions per session so concurrent sessions each notify', async () => {
+    const service = new NotificationService(
+      {
+        getNotificationsEnabled,
+      },
+      outputChannel,
+      {
+        createEventClient,
+        cooldownMs: 0,
+      }
+    );
+
+    service.syncConnection(4700);
+
+    clientCallbacks?.onEvent(createStatusEvent('busy', 'session-A'));
+    clientCallbacks?.onEvent(createStatusEvent('busy', 'session-B'));
+
+    // Session A finishes first and must notify for its own transition.
+    clientCallbacks?.onEvent(createStatusEvent('idle', 'session-A'));
+    expect(showInformationMessage).toHaveBeenCalledTimes(1);
+
+    // Session B's real completion must not be swallowed by A's notification.
+    clientCallbacks?.onEvent(createStatusEvent('idle', 'session-B'));
+    expect(showInformationMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores idle for a session that was never active while active sessions still notify', async () => {
+    const service = new NotificationService(
+      {
+        getNotificationsEnabled,
+      },
+      outputChannel,
+      {
+        createEventClient,
+        cooldownMs: 0,
+      }
+    );
+
+    service.syncConnection(4701);
+
+    clientCallbacks?.onEvent(createStatusEvent('busy', 'session-A'));
+    clientCallbacks?.onEvent(createStatusEvent('idle', 'session-B'));
+
+    expect(showInformationMessage).not.toHaveBeenCalled();
+
+    clientCallbacks?.onEvent(createStatusEvent('idle', 'session-A'));
+
+    expect(showInformationMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets reconnect backoff to the base delay after a valid event is received', async () => {
+    const service = new NotificationService(
+      {
+        getNotificationsEnabled,
+      },
+      outputChannel,
+      {
+        createEventClient,
+        reconnectDelayMs: 100,
+        maxReconnectDelayMs: 400,
+      }
+    );
+
+    service.syncConnection(4800);
+
+    clientCallbacks?.onDisconnect(new Error('drop 1'));
+    await vi.advanceTimersByTimeAsync(100);
+
+    clientCallbacks?.onDisconnect(new Error('drop 2'));
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(start).toHaveBeenCalledTimes(3);
+
+    // A valid domain event proves the stream recovered; backoff resets to base.
+    clientCallbacks?.onEvent(createSessionStatusEvent('working'));
+
+    clientCallbacks?.onDisconnect(new Error('drop 3'));
+    await vi.advanceTimersByTimeAsync(99);
+    expect(start).toHaveBeenCalledTimes(3);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(start).toHaveBeenCalledTimes(4);
+    expect(start).toHaveBeenNthCalledWith(4, 4800);
+  });
+
+  it('logs and swallows showInformationMessage failures', async () => {
+    showInformationMessage.mockRejectedValueOnce(new Error('ui failed'));
+
+    const service = new NotificationService(
+      {
+        getNotificationsEnabled,
+      },
+      outputChannel,
+      {
+        createEventClient,
+      }
+    );
+
+    service.syncConnection(4600);
+    clientCallbacks?.onEvent(createSessionStatusEvent('working'));
+    clientCallbacks?.onEvent(createSessionStatusEvent('idle'));
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    expect(outputChannel.error).toHaveBeenCalledWith(
+      'Failed to show OpenCode completion notification: ui failed'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds VS Code notifications that fire when the active OpenCode runtime returns to **idle after doing work**, so you're told when a task finishes — even if you've switched to another window.

## What's included

- **`OpenCodeEventClient`** — SSE client for the `/event` stream. Parses frames (LF and CRLF), reconnects with exponential backoff, and guards disconnect callbacks by connection *generation* to avoid stale-callback races / socket leaks when restarting the stream.
- **`NotificationService`** — detects `busy → idle` transitions **per `sessionID`** (so concurrent sessions don't cross-fire), with a global cooldown to avoid spam. Reacts to connection-state changes and reloads only when its own setting changes.
- **`ConnectionService.connectToKnownPort()`** — attaches to a known runtime port **without relying on process discovery**, so the notification listener also arms when opening OpenCode via **"Open in OpenCode"** (previously only `ensureConnected` commands established a monitored connection).
- **New command** `OpenCode: Toggle Notifications` and **setting** `opencode.notificationsEnabled` (default: `true`).

## Behavior notes

- The notification is an in-VS-Code toast (`showInformationMessage`) plus an entry in the Notifications bell — consistent across all platforms.
- **Cross-platform:** the feature relies on Node `http`/`https` for the SSE stream and standard VS Code APIs; no OS-specific code is added. (Instance discovery/spawn remains as-is, already branched per platform.)

## Testing

- `npm test` → **215 passed / 3 skipped** (19 files)
- `npm run lint`, `npm run format:check`, `npm run compile` — all clean.
- Verified end-to-end against a live OpenCode runtime (`GET /path` matched the workspace, `GET /event` streamed events); the notification fires on `busy → idle`.
