### PR TITLE
fix: guard stale SSE events, clean up notifications, and fix explainAndFix command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,13 +186,3 @@ Before submitting any changes:
 3. [ ] Run `npm run test:unit` - unit tests pass
 4. [ ] Run `npm run compile` - TypeScript compiles without errors
 5. [ ] Check for any `// TODO:` comments that should be addressed
-
-## graphify
-
-This project has a graphify knowledge graph at graphify-out/.
-
-Rules:
-- Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
-- If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
-- For cross-module "how does X relate to Y" questions, prefer `graphify query "<question>"`, `graphify path "<A>" "<B>"`, or `graphify explain "<concept>"` over grep — these traverse the graph's EXTRACTED + INFERRED edges instead of scanning files
-- After modifying code files in this session, run `graphify update .` to keep the graph current (AST-only, no API cost)

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "icon": "$(terminal-tmux)"
       },
       {
-        "command": "opencode.explainAndFix",
+        "command": "opencodeConnector.explainAndFix",
         "title": "Explain and Fix (OpenCode)"
       },
       {

--- a/src/api/openCodeEventClient.ts
+++ b/src/api/openCodeEventClient.ts
@@ -95,7 +95,13 @@ export class OpenCodeEventClient {
     // cannot clobber the current connection or trigger a spurious reconnect.
     const generation = ++this.generation;
     this.connection = this.createStream(getEventUrl(port), {
-      onChunk: chunk => this.handleChunk(chunk),
+      onChunk: chunk => {
+        if (generation !== this.generation || this.stopped) {
+          return;
+        }
+
+        this.handleChunk(chunk);
+      },
       onDisconnect: error => {
         if (generation !== this.generation) {
           // Stale disconnect from a connection that has already been replaced

--- a/src/api/openCodeEventClient.ts
+++ b/src/api/openCodeEventClient.ts
@@ -124,7 +124,6 @@ export class OpenCodeEventClient {
   }
 
   private handleChunk(chunk: string): void {
-    this.logger.info(`Raw SSE chunk (${chunk.length} chars): ${JSON.stringify(chunk)}`);
     this.buffer += chunk;
 
     while (true) {
@@ -162,8 +161,6 @@ export class OpenCodeEventClient {
   }
 
   private emitFrame(rawFrame: string): void {
-    this.logger.info(`Raw SSE frame (${rawFrame.length} chars): ${JSON.stringify(rawFrame)}`);
-
     const lines = rawFrame.split(/\r?\n/);
     const data = lines
       .filter(line => line.startsWith('data:'))
@@ -177,13 +174,11 @@ export class OpenCodeEventClient {
         .trim() || 'message';
 
     if (!lines.some(line => line.startsWith('event:'))) {
-      this.logger.info(
-        `SSE frame omitted event line; defaulting to SSE event "message": ${JSON.stringify(rawFrame)}`
-      );
+      this.logger.info('SSE frame omitted event line; defaulting to SSE event "message"');
     }
 
     if (!data) {
-      this.logger.warn(`Ignoring SSE frame without data payload: ${JSON.stringify(rawFrame)}`);
+      this.logger.warn('Ignoring SSE frame without data payload');
       return;
     }
 
@@ -193,23 +188,17 @@ export class OpenCodeEventClient {
       const properties = parsed.properties;
 
       if (!domainType || typeof properties !== 'object' || properties === null) {
-        this.logger.warn(`Ignoring malformed SSE frame payload: ${JSON.stringify(parsed)}`);
+        this.logger.warn('Ignoring malformed SSE frame payload');
         return;
       }
 
-      this.logger.info(
-        `Parsed OpenCode event: ${JSON.stringify({
-          sseEvent: sseEventName,
-          type: domainType,
-          properties,
-        })}`
-      );
+      this.logger.info(`Parsed OpenCode event: sseEvent=${sseEventName} type=${domainType}`);
       this.callbacks.onEvent({
         type: domainType,
         properties: properties as Record<string, unknown>,
       });
     } catch {
-      this.logger.warn(`Ignoring malformed SSE frame: ${JSON.stringify(rawFrame)}`);
+      this.logger.warn('Ignoring malformed SSE frame');
     }
   }
 }

--- a/src/api/openCodeEventClient.ts
+++ b/src/api/openCodeEventClient.ts
@@ -165,8 +165,7 @@ export class OpenCodeEventClient {
     this.logger.info(`Raw SSE frame (${rawFrame.length} chars): ${JSON.stringify(rawFrame)}`);
 
     const lines = rawFrame.split(/\r?\n/);
-    const data = rawFrame
-      .split(/\r?\n/)
+    const data = lines
       .filter(line => line.startsWith('data:'))
       .map(line => line.slice('data:'.length).trim())
       .join('\n');

--- a/src/commands/openNewInstance.ts
+++ b/src/commands/openNewInstance.ts
@@ -54,12 +54,8 @@ export async function openOpencodeForWorkspace(
           }
 
           outputChannel.info(
-            `[openOpencodeForWorkspace] No tracked terminal for port ${existingPort}, opening editor tab`
+            `[openOpencodeForWorkspace] No tracked terminal for port ${existingPort}, attaching to existing instance`
           );
-          await instanceManager.spawnInTerminal(existingPort, {
-            cwd: workspacePath,
-            asEditor: true,
-          });
           await connectionService.connectToKnownPort(existingPort);
           vscode.window.setStatusBarMessage(
             `$(check) Reconnected to OpenCode on port ${existingPort}`,

--- a/src/commands/openNewInstance.ts
+++ b/src/commands/openNewInstance.ts
@@ -54,7 +54,14 @@ export async function openOpencodeForWorkspace(
           }
 
           outputChannel.info(
-            `[openOpencodeForWorkspace] No tracked terminal for port ${existingPort}, attaching to existing instance`
+            `[openOpencodeForWorkspace] No tracked terminal for port ${existingPort}, opening editor tab`
+          );
+          await instanceManager.attachToTerminal(existingPort, {
+            cwd: workspacePath,
+            asEditor: true,
+          });
+          outputChannel.info(
+            `[openOpencodeForWorkspace] Attaching to existing instance on port ${existingPort}`
           );
           await connectionService.connectToKnownPort(existingPort);
           vscode.window.setStatusBarMessage(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -94,9 +94,6 @@ export function activate(extensionUri: vscode.Uri, context: vscode.ExtensionCont
       .discoverAndConnect()
       .then(connected => {
         statusBarManager?.updateConnectionStatus(connected, connectionService?.getPort());
-        if (connected) {
-          notificationService?.syncConnection(connectionService?.getPort());
-        }
       })
       .catch(() => {
         statusBarManager?.updateConnectionStatus(false);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -192,7 +192,7 @@ export function registerCommands(): void {
   );
 
   const explainAndFixCommand = vscode.commands.registerCommand(
-    'opencode.explainAndFix',
+    'opencodeConnector.explainAndFix',
     async (diagnostic: vscode.Diagnostic, uri: vscode.Uri) => {
       if (!diagnostic || !uri) {
         outputChannel?.warn(

--- a/src/instance/instanceManager.ts
+++ b/src/instance/instanceManager.ts
@@ -587,24 +587,11 @@ export class InstanceManager {
     return this.portToTerminal.get(port);
   }
 
-  /**
-   * Spawn an OpenCode instance in a VSCode Integrated Terminal.
-   * @param port - Port number to use for the instance
-   * @param options - Optional spawn options (cwd, asEditor)
-   * @returns Promise<void>
-   */
-  public async spawnInTerminal(port: number, options?: SpawnTerminalOptions): Promise<void> {
+  private createTerminalOptions(options?: SpawnTerminalOptions): vscode.TerminalOptions {
     const workspacePath = options?.cwd ?? this.getWorkspacePath();
     const workspaceHash = WorkspaceUtils.getWorkspaceHash(workspacePath);
-    const terminalName = `OpenCode: ${workspaceHash}`;
-    const binaryPath = this.configManager.getBinaryPath() || 'opencode';
-    // Don't use getCommandWithExtension here — the integrated terminal shell
-    // resolves binaries via PATH naturally (handles .exe, aliases, etc.)
-    const fullCommand = `${binaryPath} --port ${port}`;
-
-    // Build terminal creation options
     const terminalCreationOptions: vscode.TerminalOptions = {
-      name: terminalName,
+      name: `OpenCode: ${workspaceHash}`,
       cwd: workspacePath,
     };
 
@@ -612,35 +599,60 @@ export class InstanceManager {
       terminalCreationOptions.location = vscode.TerminalLocation.Editor;
     }
 
-    // Check for existing terminal with the same name
-    const existingTerminal = vscode.window.terminals.find(t => t.name === terminalName);
+    return terminalCreationOptions;
+  }
+
+  private async openTerminalWithCommand(
+    port: number,
+    command: string,
+    options?: SpawnTerminalOptions
+  ): Promise<void> {
+    const terminalCreationOptions = this.createTerminalOptions(options);
+    const existingTerminal = vscode.window.terminals.find(
+      terminal => terminal.name === terminalCreationOptions.name
+    );
 
     if (existingTerminal) {
-      // Send Ctrl+C to stop any previous process
-      // On Windows, multiple Ctrl+C or a small delay might be needed
       existingTerminal.sendText('\x03');
-
-      // Small delay to ensure shell processes the interrupt
       await new Promise(resolve => setTimeout(resolve, 100));
-
-      // Send the new command
-      existingTerminal.sendText(fullCommand);
-
-      // Track this terminal for the port
+      existingTerminal.sendText(command);
       this.portToTerminal.set(port, existingTerminal);
-    } else {
-      // Create a new terminal, make it visible and focused
-      const terminal = vscode.window.createTerminal(terminalCreationOptions);
-      terminal.show(false);
-
-      // Wait for shell to initialize before sending the command
-      await new Promise(resolve => setTimeout(resolve, 500));
-
-      terminal.sendText(fullCommand);
-
-      // Track this terminal for the port
-      this.portToTerminal.set(port, terminal);
+      return;
     }
+
+    const terminal = vscode.window.createTerminal(terminalCreationOptions);
+    terminal.show(false);
+    await new Promise(resolve => setTimeout(resolve, 500));
+    terminal.sendText(command);
+    this.portToTerminal.set(port, terminal);
+  }
+
+  /**
+   * Attach a VS Code terminal to an already-running OpenCode server.
+   * @param port - Running OpenCode server port to attach to
+   * @param options - Optional terminal options (cwd, asEditor)
+   * @returns Promise<void>
+   */
+  public async attachToTerminal(port: number, options?: SpawnTerminalOptions): Promise<void> {
+    const binaryPath = this.configManager.getBinaryPath() || 'opencode';
+    await this.openTerminalWithCommand(
+      port,
+      `${binaryPath} attach http://127.0.0.1:${port}`,
+      options
+    );
+  }
+
+  /**
+   * Spawn an OpenCode instance in a VSCode Integrated Terminal.
+   * @param port - Port number to use for the instance
+   * @param options - Optional spawn options (cwd, asEditor)
+   * @returns Promise<void>
+   */
+  public async spawnInTerminal(port: number, options?: SpawnTerminalOptions): Promise<void> {
+    const binaryPath = this.configManager.getBinaryPath() || 'opencode';
+    // Don't use getCommandWithExtension here — the integrated terminal shell
+    // resolves binaries via PATH naturally (handles .exe, aliases, etc.)
+    await this.openTerminalWithCommand(port, `${binaryPath} --port ${port}`, options);
   }
 
   /**

--- a/src/notifications/notificationService.ts
+++ b/src/notifications/notificationService.ts
@@ -78,17 +78,14 @@ export class NotificationService {
 
     const previousPort = this.activePort;
     this.activePort = port;
-    this.resetStreamState();
-    this.clearReconnectTimer();
-    this.reconnectAttempt = 0;
     if (previousPort !== undefined) {
-      this.outputChannel?.info(`Stopping OpenCode notification listener on port ${previousPort}`);
-      this.eventClient.stop();
+      this.stopListening(previousPort);
+    } else {
+      this.resetListenerState();
     }
 
     if (port !== undefined && this.config.getNotificationsEnabled()) {
-      this.outputChannel?.info(`Starting OpenCode notification listener on port ${port}`);
-      this.eventClient.start(port);
+      this.startListening(port);
     }
   }
 
@@ -96,14 +93,10 @@ export class NotificationService {
    * Reload notification behavior after a settings change.
    */
   public reloadSettings(): void {
-    this.clearReconnectTimer();
-    this.reconnectAttempt = 0;
-    this.resetStreamState();
     if (this.activePort !== undefined) {
-      this.outputChannel?.info(
-        `Stopping OpenCode notification listener on port ${this.activePort}`
-      );
-      this.eventClient.stop();
+      this.stopListening(this.activePort);
+    } else {
+      this.resetListenerState();
     }
 
     if (!this.config.getNotificationsEnabled()) {
@@ -112,10 +105,7 @@ export class NotificationService {
     }
 
     if (this.activePort !== undefined) {
-      this.outputChannel?.info(
-        `Starting OpenCode notification listener on port ${this.activePort}`
-      );
-      this.eventClient.start(this.activePort);
+      this.startListening(this.activePort);
     }
   }
 
@@ -123,15 +113,11 @@ export class NotificationService {
    * Dispose notification resources.
    */
   public dispose(): void {
-    this.clearReconnectTimer();
-    this.reconnectAttempt = 0;
-    this.resetStreamState();
     if (this.activePort !== undefined) {
-      this.outputChannel?.info(
-        `Stopping OpenCode notification listener on port ${this.activePort}`
-      );
+      this.stopListening(this.activePort);
+    } else {
+      this.resetListenerState();
     }
-    this.eventClient.stop();
   }
 
   private handleEvent(event: { type: string; properties: Record<string, unknown> }): void {
@@ -222,6 +208,23 @@ export class NotificationService {
   private resetStreamState(): void {
     this.activeSessions.clear();
     this.lastNotificationAt = 0;
+  }
+
+  private resetListenerState(): void {
+    this.clearReconnectTimer();
+    this.reconnectAttempt = 0;
+    this.resetStreamState();
+  }
+
+  private stopListening(port: number): void {
+    this.resetListenerState();
+    this.outputChannel?.info(`Stopping OpenCode notification listener on port ${port}`);
+    this.eventClient.stop();
+  }
+
+  private startListening(port: number): void {
+    this.outputChannel?.info(`Starting OpenCode notification listener on port ${port}`);
+    this.eventClient.start(port);
   }
 
   private async showCompletionNotification(): Promise<void> {

--- a/src/providers/codeActionProvider.ts
+++ b/src/providers/codeActionProvider.ts
@@ -65,7 +65,7 @@ export class OpenCodeCodeActionProvider implements vscode.CodeActionProvider {
       // Set the command to execute
       action.command = {
         title: 'Explain and Fix (OpenCode)',
-        command: 'opencode.explainAndFix',
+        command: 'opencodeConnector.explainAndFix',
         arguments: [diagnostic, document.uri],
       };
 

--- a/test/api/openCodeEventClient.test.ts
+++ b/test/api/openCodeEventClient.test.ts
@@ -201,6 +201,34 @@ describe('OpenCodeEventClient', () => {
     expect(secondConnection.close).toHaveBeenCalledTimes(1);
   });
 
+  it('ignores late chunks from previous or stopped connections', () => {
+    const client = new OpenCodeEventClient(
+      { onEvent, onDisconnect },
+      {
+        createStream,
+        logger,
+      }
+    );
+
+    client.start(4600);
+    const firstConnection = connections[0];
+
+    client.start(4601);
+    firstConnection.handlers.onChunk(
+      'event: message\ndata: {"id":"evt-old","type":"session.status","properties":{"sessionID":"old-session","status":{"type":"idle"}}}\n\n'
+    );
+
+    expect(onEvent).not.toHaveBeenCalled();
+
+    const secondConnection = connections[1];
+    client.stop();
+    secondConnection.handlers.onChunk(
+      'event: message\ndata: {"id":"evt-stopped","type":"session.status","properties":{"sessionID":"stopped-session","status":{"type":"idle"}}}\n\n'
+    );
+
+    expect(onEvent).not.toHaveBeenCalled();
+  });
+
   it('parses frames separated by CRLF boundaries across a split chunk', () => {
     const client = new OpenCodeEventClient(
       { onEvent, onDisconnect },

--- a/test/api/openCodeEventClient.test.ts
+++ b/test/api/openCodeEventClient.test.ts
@@ -9,7 +9,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 describe('OpenCodeEventClient', () => {
   let onEvent: ReturnType<typeof vi.fn>;
   let onDisconnect: ReturnType<typeof vi.fn>;
-  let createStream: ReturnType<typeof vi.fn<OpenCodeEventStreamFactory>>;
+  let createStream: ReturnType<
+    typeof vi.fn<Parameters<OpenCodeEventStreamFactory>, OpenCodeEventStreamConnection>
+  >;
   let logger: {
     info: ReturnType<typeof vi.fn>;
     warn: ReturnType<typeof vi.fn>;
@@ -83,9 +85,12 @@ describe('OpenCodeEventClient', () => {
         status: { type: 'busy' },
       },
     });
-    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Raw SSE chunk'));
-    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Raw SSE frame'));
-    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Parsed OpenCode event'));
+    expect(logger.info).toHaveBeenCalledWith(
+      'Parsed OpenCode event: sseEvent=message type=session.status'
+    );
+    expect(logger.info.mock.calls.flat().join('\n')).not.toContain('Raw SSE chunk');
+    expect(logger.info.mock.calls.flat().join('\n')).not.toContain('Raw SSE frame');
+    expect(logger.info.mock.calls.flat().join('\n')).not.toContain('session-1');
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('Ignoring malformed SSE frame')
     );
@@ -140,7 +145,9 @@ describe('OpenCodeEventClient', () => {
     expect(logger.info).toHaveBeenCalledWith(
       expect.stringContaining('defaulting to SSE event "message"')
     );
-    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('"sseEvent":"message"'));
+    expect(logger.info).toHaveBeenCalledWith(
+      'Parsed OpenCode event: sseEvent=message type=session.status'
+    );
     expect(logger.warn.mock.calls.flat().join('\n')).not.toContain('without event line');
   });
 

--- a/test/commands/openNewInstance.test.ts
+++ b/test/commands/openNewInstance.test.ts
@@ -73,7 +73,7 @@ describe('openOpencodeForWorkspace notification/connection wiring', () => {
     expect(connectionService.connectToKnownPort).toHaveBeenCalledWith(4096);
   });
 
-  it('attaches to an existing port without a tracked terminal after opening a tab', async () => {
+  it('attaches to an existing port without a tracked terminal without re-spawning', async () => {
     const { connectionService, instanceManager, outputChannel } = createDeps();
     connectionService.findPortForWorkspace.mockResolvedValueOnce(4096);
     instanceManager.getTerminalForPort.mockReturnValueOnce(undefined);
@@ -85,10 +85,7 @@ describe('openOpencodeForWorkspace notification/connection wiring', () => {
       outputChannel as never
     );
 
-    expect(instanceManager.spawnInTerminal).toHaveBeenCalledWith(4096, {
-      cwd: '/workspace/app',
-      asEditor: true,
-    });
+    expect(instanceManager.spawnInTerminal).not.toHaveBeenCalled();
     expect(connectionService.connectToKnownPort).toHaveBeenCalledWith(4096);
   });
 });

--- a/test/commands/openNewInstance.test.ts
+++ b/test/commands/openNewInstance.test.ts
@@ -21,6 +21,7 @@ function createDeps() {
   const instanceManager = {
     getTerminalForPort: vi.fn(() => undefined as { show: (b: boolean) => void } | undefined),
     spawnInTerminal: vi.fn(async () => undefined),
+    attachToTerminal: vi.fn(async () => undefined),
     findAvailablePort: vi.fn(async () => 5005),
   };
   const outputChannel = {
@@ -73,7 +74,7 @@ describe('openOpencodeForWorkspace notification/connection wiring', () => {
     expect(connectionService.connectToKnownPort).toHaveBeenCalledWith(4096);
   });
 
-  it('attaches to an existing port without a tracked terminal without re-spawning', async () => {
+  it('opens an editor tab and attaches to an existing port without a tracked terminal', async () => {
     const { connectionService, instanceManager, outputChannel } = createDeps();
     connectionService.findPortForWorkspace.mockResolvedValueOnce(4096);
     instanceManager.getTerminalForPort.mockReturnValueOnce(undefined);
@@ -85,6 +86,10 @@ describe('openOpencodeForWorkspace notification/connection wiring', () => {
       outputChannel as never
     );
 
+    expect(instanceManager.attachToTerminal).toHaveBeenCalledWith(4096, {
+      cwd: '/workspace/app',
+      asEditor: true,
+    });
     expect(instanceManager.spawnInTerminal).not.toHaveBeenCalled();
     expect(connectionService.connectToKnownPort).toHaveBeenCalledWith(4096);
   });

--- a/test/extension/notificationWiring.test.ts
+++ b/test/extension/notificationWiring.test.ts
@@ -251,6 +251,6 @@ describe('notification wiring in extension', () => {
     deactivate();
 
     expect(extensionState.eventClientStart).toHaveBeenNthCalledWith(1, 4300);
-    expect(extensionState.eventClientStop).toHaveBeenCalledTimes(2);
+    expect(extensionState.eventClientStop).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/instance/instanceManager.test.ts
+++ b/test/instance/instanceManager.test.ts
@@ -4,8 +4,8 @@
 import { ConfigManager } from '../../src/config';
 import { InstanceManager, PlatformUtils } from '../../src/instance/instanceManager';
 
-import * as net from 'net';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
 
 vi.mock('vscode', () => ({
   workspace: {
@@ -22,7 +22,11 @@ vi.mock('vscode', () => ({
   },
   window: {
     terminals: [] as unknown[],
+    createTerminal: vi.fn(),
     onDidCloseTerminal: vi.fn(() => ({ dispose: vi.fn() })),
+  },
+  TerminalLocation: {
+    Editor: 1,
   },
 }));
 
@@ -48,6 +52,9 @@ describe('InstanceManager', () => {
     InstanceManager.resetInstance();
     mockConfigManager = createMockConfigManager(3000, 'opencode');
     instanceManager = InstanceManager.getInstance(mockConfigManager as unknown as ConfigManager);
+    vi.mocked(vscode.window.createTerminal).mockReset();
+    const terminals = vscode.window.terminals as vscode.Terminal[];
+    terminals.splice(0, terminals.length);
   });
 
   afterEach(() => {
@@ -104,6 +111,35 @@ describe('InstanceManager', () => {
       const testConfig = createMockConfigManager(port, 'opencode');
       const testManager = InstanceManager.getInstance(testConfig);
       expect(testManager.getPort()).toBe(port);
+    });
+  });
+
+  describe('attachToTerminal', () => {
+    it('opens an editor terminal with opencode attach instead of starting a duplicate server', async () => {
+      const sendText = vi.fn();
+      const show = vi.fn();
+      const terminal = {
+        name: 'OpenCode: test-workspace',
+        sendText,
+        show,
+      } as unknown as vscode.Terminal;
+      vi.mocked(vscode.window.createTerminal).mockReturnValueOnce(terminal);
+
+      const attachPromise = instanceManager.attachToTerminal(4096, {
+        cwd: '/workspace/app',
+        asEditor: true,
+      });
+      await attachPromise;
+
+      expect(vscode.window.createTerminal).toHaveBeenCalledWith({
+        name: expect.stringMatching(/^OpenCode: /),
+        cwd: '/workspace/app',
+        location: vscode.TerminalLocation.Editor,
+      });
+      expect(show).toHaveBeenCalledWith(false);
+      expect(sendText).toHaveBeenCalledWith('opencode attach http://127.0.0.1:4096');
+      expect(sendText).not.toHaveBeenCalledWith('opencode --port 4096');
+      expect(instanceManager.getTerminalForPort(4096)).toBe(terminal);
     });
   });
 });

--- a/test/providers/codeActionProvider.test.ts
+++ b/test/providers/codeActionProvider.test.ts
@@ -165,12 +165,12 @@ describe('CodeActionProvider Logic', () => {
     it('should set correct action properties', () => {
       const title = 'Explain and Fix (OpenCode)';
       const kindValue = 'quickfix';
-      const commandName = 'opencode.explainAndFix';
+      const commandName = 'opencodeConnector.explainAndFix';
       const isPreferred = true;
 
       expect(title).toBe('Explain and Fix (OpenCode)');
       expect(kindValue).toBe('quickfix');
-      expect(commandName).toBe('opencode.explainAndFix');
+      expect(commandName).toBe('opencodeConnector.explainAndFix');
       expect(isPreferred).toBe(true);
     });
   });


### PR DESCRIPTION
## Summary

Multiple fixes and cleanups for the notification system and SSE event handling.

## Changes

- **fix: guard SSE onChunk with generation/stopped flag** — prevents stale stream events from being processed after a generation is cancelled
- **fix: attach to existing OpenCode instance** — avoids starting duplicate server processes when reconnecting
- **fix: remove raw SSE payload logging** — stops logging full SSE payloads at info level
- **fix: attach existing port with respawning** — handles port attachment more reliably
- **refactor: rename `opencode.explainAndFix` → `opencodeConnector.explainAndFix`** — aligns command naming convention with other extension commands
- **feat: notify when OpenCode sessions return to idle** — fires VS Code notifications on session state transitions
- **chore: clean duplicate wiring**
- **docs: remove stale graphify section from AGENTS.md**

## Key Components

- `OpenCodeEventClient` — SSE client for the /event stream with LF/CRLF frame parsing
- `NotificationService` — per-session busy→idle detection with global cooldown
- `ConnectionService.connectToKnownPort()` — attaches to a known runtime port without duplicate connection
- New command: `OpenCode: Toggle Notifications`
- New setting: `opencode.notifications.enabled`

## Testing

Unit tests added for event client, notification service, and extension wiring.